### PR TITLE
Merge dev into main

### DIFF
--- a/.claude/commands/fastlane-changelog.md
+++ b/.claude/commands/fastlane-changelog.md
@@ -1,21 +1,18 @@
 # Fastlane Changelog Generator
 
-Generate the Fastlane changelog files for the current app version before a Google Play release.
+Generate the Fastlane changelog files before a Google Play release.
+
+> **Note:** This project uses release-please, so the exact next versionCode is unknown until the release PR merges. Changelogs are always written to `default.txt` — Fastlane uses it as a fallback when no versionCode-specific file is found.
 
 ## Steps
 
-1. Read `app/build.gradle.kts` and extract `appVersionName` (format `"X.Y.Z"`).
-
-2. Calculate `versionCode` using the same formula as the build file:
-   `vMajor * 1_000_000 + vMinor * 1_000 + vPatch`
-
-3. Check if `fastlane/metadata/android/` exists. If not, create the full directory tree:
+1. Check if `fastlane/metadata/android/` exists. If not, create the full directory tree:
    - `fastlane/metadata/android/es-419/changelogs/`
    - `fastlane/metadata/android/en-US/changelogs/`
 
-4. Check if a changelog for the current `versionCode` already exists in both locales. If it does, show its content and ask the user if they want to overwrite it.
+2. Check if `default.txt` already exists in both locales. If it does, show its content and ask the user if they want to overwrite it.
 
-5. Extract changes from git commits:
+3. Extract changes from git commits:
    - Find the latest git tag with `git describe --tags --abbrev=0`. If no tag exists, use the first commit.
    - Run `git log <tag>..HEAD --oneline --no-merges` to get all commits since that tag.
    - Filter and interpret the commits following these rules:
@@ -26,19 +23,16 @@ Generate the Fastlane changelog files for the current app version before a Googl
      - If after filtering no user-visible commits remain, say so and ask the user to provide a brief description manually.
    - Show the raw filtered commit list to the user before generating the notes, so they can flag anything that should be excluded or reworded.
 
-6. Generate polished, concise release notes (max 500 characters each) in:
+4. Generate polished, concise release notes (max 500 characters each) in:
    - **Spanish (es-419):** simple and friendly tone, suitable for Chilean/Latin American users.
    - **English (en-US):** matching tone and content.
    - Show both drafts to the user and ask for confirmation or edits before writing.
 
-6. Write the confirmed content to:
-   - `fastlane/metadata/android/es-419/changelogs/<versionCode>.txt`
-   - `fastlane/metadata/android/en-US/changelogs/<versionCode>.txt`
+5. Write the confirmed content to:
+   - `fastlane/metadata/android/es-419/changelogs/default.txt`
+   - `fastlane/metadata/android/en-US/changelogs/default.txt`
 
-7. Also ensure `default.txt` exists in both locale folders (copy from the new file if it doesn't exist yet).
-
-8. Report a summary:
-   - Version name and code used
+6. Report a summary:
    - Files created or updated
    - Character count for each changelog (reminder: Google Play limit is 500 chars)
    - Next step hint: run `fastlane beta_googleplay` or `fastlane prod_googleplay`

--- a/.claude/commands/fastlane-changelog.md
+++ b/.claude/commands/fastlane-changelog.md
@@ -1,0 +1,44 @@
+# Fastlane Changelog Generator
+
+Generate the Fastlane changelog files for the current app version before a Google Play release.
+
+## Steps
+
+1. Read `app/build.gradle.kts` and extract `appVersionName` (format `"X.Y.Z"`).
+
+2. Calculate `versionCode` using the same formula as the build file:
+   `vMajor * 1_000_000 + vMinor * 1_000 + vPatch`
+
+3. Check if `fastlane/metadata/android/` exists. If not, create the full directory tree:
+   - `fastlane/metadata/android/es-419/changelogs/`
+   - `fastlane/metadata/android/en-US/changelogs/`
+
+4. Check if a changelog for the current `versionCode` already exists in both locales. If it does, show its content and ask the user if they want to overwrite it.
+
+5. Extract changes from git commits:
+   - Find the latest git tag with `git describe --tags --abbrev=0`. If no tag exists, use the first commit.
+   - Run `git log <tag>..HEAD --oneline --no-merges` to get all commits since that tag.
+   - Filter and interpret the commits following these rules:
+     - **Include:** `feat`, `fix`, `perf` — these are user-visible changes.
+     - **Exclude:** `chore`, `refactor`, `test`, `ci`, `build`, `docs` — internal/technical, not relevant to end users.
+     - **Simplify language:** convert technical commit messages into plain, user-friendly phrases. Never expose library names, internal module names, class names, or implementation details (e.g. "migrate Coil 3.4.0" → "mejoras en la carga de imágenes").
+     - **Group similar changes** into a single bullet instead of listing each commit separately.
+     - If after filtering no user-visible commits remain, say so and ask the user to provide a brief description manually.
+   - Show the raw filtered commit list to the user before generating the notes, so they can flag anything that should be excluded or reworded.
+
+6. Generate polished, concise release notes (max 500 characters each) in:
+   - **Spanish (es-419):** simple and friendly tone, suitable for Chilean/Latin American users.
+   - **English (en-US):** matching tone and content.
+   - Show both drafts to the user and ask for confirmation or edits before writing.
+
+6. Write the confirmed content to:
+   - `fastlane/metadata/android/es-419/changelogs/<versionCode>.txt`
+   - `fastlane/metadata/android/en-US/changelogs/<versionCode>.txt`
+
+7. Also ensure `default.txt` exists in both locale folders (copy from the new file if it doesn't exist yet).
+
+8. Report a summary:
+   - Version name and code used
+   - Files created or updated
+   - Character count for each changelog (reminder: Google Play limit is 500 chars)
+   - Next step hint: run `fastlane beta_googleplay` or `fastlane prod_googleplay`

--- a/README.md
+++ b/README.md
@@ -4,11 +4,12 @@
 <h1 align="center"><a href="https://play.google.com/store/apps/details?id=cl.figonzal.lastquakechile">LastQuakeChile</a></h1>
 
 <p align="center">
+  <a href="https://play.google.com/store/apps/details?id=cl.figonzal.lastquakechile">
+          <img alt="Google Play Badge" src="https://img.shields.io/endpoint?color=green&logo=google-play&logoColor=green&url=https%3A%2F%2Fplay.cuzi.workers.dev%2Fplay%3Fi%3Dcl.figonzal.lastquakechile%26gl%3Dcl%26hl%3Den%26l%3DGoogle%2520Play%26m%3DVersion%253A%2520%24version%2520%257C%2520Downloads%253A%2520%2524shortinstalls%2520%257C%2520Updated%253A%2520%2524updated">
+    </a>
 
-  <a href="https://snyk.io/test/github/figonzal1/LastQuakeChile?targetFile=app/build.gradle" >
-        <img alt="Snyk" src="https://snyk.io/test/github/figonzal1/LastQuakeChile/badge.svg?targetFile=app/build.gradle" >
-  </a>
-
+  <a href="https://wakatime.com/badge/github/figonzal1/LastQuakeChile"><img src="https://wakatime.com/badge/github/figonzal1/LastQuakeChile.svg" alt="wakatime"></a>
+  
   <a href="https://www.codefactor.io/repository/github/figonzal1/LastQuakeChile" >
         <img src="https://www.codefactor.io/repository/github/figonzal1/LastQuakeChile/badge" >
   </a>
@@ -24,9 +25,7 @@
    <a href="https://img.shields.io/github/last-commit/figonzal1/LastQuakeChile?color=yellow" >
         <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/figonzal1/LastQuakeChile?color=yellow">
    </a>
-  <a href="https://play.google.com/store/apps/details?id=cl.figonzal.lastquakechile">
-        <img alt="Google Play Badge" src="https://img.shields.io/endpoint?color=green&logo=google-play&logoColor=green&url=https%3A%2F%2Fplay.cuzi.workers.dev%2Fplay%3Fi%3Dcl.figonzal.lastquakechile%26l%3DGoogle%2520Play%26m%3DVersion%253A%2520%24version%2520%257C%2520Downloads%2520%2524shortinstalls%2520%257C%2520Updated%253A%2520%2524updated">
-  </a>
+  
 </p>
 
 This is the repository of the **LastQuakeChile application - Earthquakes in Chile**

--- a/README.md
+++ b/README.md
@@ -7,25 +7,22 @@
   <a href="https://play.google.com/store/apps/details?id=cl.figonzal.lastquakechile">
           <img alt="Google Play Badge" src="https://img.shields.io/endpoint?color=green&logo=google-play&logoColor=green&url=https%3A%2F%2Fplay.cuzi.workers.dev%2Fplay%3Fi%3Dcl.figonzal.lastquakechile%26gl%3Dcl%26hl%3Den%26l%3DGoogle%2520Play%26m%3DVersion%253A%2520%24version%2520%257C%2520Downloads%253A%2520%2524shortinstalls%2520%257C%2520Updated%253A%2520%2524updated">
     </a>
+  </p>
 
+<p align="center">
   <a href="https://wakatime.com/badge/github/figonzal1/LastQuakeChile"><img src="https://wakatime.com/badge/github/figonzal1/LastQuakeChile.svg" alt="wakatime"></a>
-  
   <a href="https://www.codefactor.io/repository/github/figonzal1/LastQuakeChile" >
         <img src="https://www.codefactor.io/repository/github/figonzal1/LastQuakeChile/badge" >
   </a>
-
   <a href="https://img.shields.io/github/languages/top/figonzal1/LastQuakeChile?color=orange" >
         <img alt="GitHub repo language" src="https://img.shields.io/github/languages/top/figonzal1/LastQuakeChile?color=orange">
   </a>
-
    <a href="https://img.shields.io/github/repo-size/figonzal1/LastQuakeChile" >
          <img alt="GitHub repo size" src="https://img.shields.io/github/repo-size/figonzal1/LastQuakeChile">
     </a>
-
    <a href="https://img.shields.io/github/last-commit/figonzal1/LastQuakeChile?color=yellow" >
         <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/figonzal1/LastQuakeChile?color=yellow">
    </a>
-  
 </p>
 
 This is the repository of the **LastQuakeChile application - Earthquakes in Chile**

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -58,3 +58,9 @@
   # kept. Suspend functions are wrapped in continuations where the type argument
   # is used.
   -keep,allowobfuscation,allowshrinking class kotlin.coroutines.Continuation
+
+# FIREBASE PERFORMANCE + PROTOBUF
+# R8 renames fields in protobuf-generated classes, breaking Firebase Perf's reflection-based schema
+-keepclassmembers class * extends com.google.protobuf.GeneratedMessageLite {
+    <fields>;
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -33,13 +33,6 @@
             android:name="com.google.android.gms.version"
             android:value="@integer/google_play_services_version" />
 
-        <meta-data
-            android:name="com.facebook.sdk.ApplicationId"
-            android:value="${FB_APP_ID}" />
-        <meta-data
-            android:name="com.facebook.sdk.ClientToken"
-            android:value="${FB_CLIENT_ID}" />
-
         <activity
             android:name=".core.ui.MainActivity"
             android:exported="true">

--- a/app/src/main/java/cl/figonzal/lastquakechile/core/services/UpdaterService.kt
+++ b/app/src/main/java/cl/figonzal/lastquakechile/core/services/UpdaterService.kt
@@ -4,6 +4,9 @@ import android.app.Activity
 import android.content.IntentSender.SendIntentException
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.IntentSenderRequest
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import com.google.android.play.core.appupdate.AppUpdateInfo
 import com.google.android.play.core.appupdate.AppUpdateManagerFactory
 import com.google.android.play.core.appupdate.AppUpdateOptions
 import com.google.android.play.core.install.model.AppUpdateType
@@ -15,12 +18,44 @@ import timber.log.Timber
 private const val FIREBASE_LQCH_UPDATER_STATUS = "lqch_updater_status"
 
 class UpdaterService(
-    activity: Activity,
+    private val activity: Activity,
     private val activityResultLauncher: ActivityResultLauncher<IntentSenderRequest>
 ) {
 
     private var manager = AppUpdateManagerFactory.create(activity)
     private var crashlytics = Firebase.crashlytics
+
+    /**
+     * The Play Core appUpdateInfo task is async; by the time it resolves the Activity may have
+     * been destroyed/recreated, which unregisters the ActivityResultLauncher. Launching it then
+     * throws IllegalStateException. Only launch while the Activity is alive and at least STARTED.
+     */
+    private fun canLaunch(): Boolean {
+        if (activity.isFinishing || activity.isDestroyed) return false
+        val owner = activity as? LifecycleOwner ?: return true
+        return owner.lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)
+    }
+
+    private fun launchUpdate(appUpdateInfo: AppUpdateInfo) {
+        if (!canLaunch()) {
+            Timber.w("Update flow skipped: activity not in valid state")
+            crashlytics.setCustomKey(FIREBASE_LQCH_UPDATER_STATUS, "Skipped: invalid lifecycle")
+            return
+        }
+        try {
+            manager.startUpdateFlowForResult(
+                appUpdateInfo,
+                activityResultLauncher,
+                AppUpdateOptions.newBuilder(AppUpdateType.IMMEDIATE).build()
+            )
+        } catch (e: SendIntentException) {
+            Timber.e(e, "Update intent failed")
+            crashlytics.setCustomKey(FIREBASE_LQCH_UPDATER_STATUS, "Update intent failed")
+        } catch (e: IllegalStateException) {
+            Timber.e(e, "Launcher unregistered when starting update flow")
+            crashlytics.setCustomKey(FIREBASE_LQCH_UPDATER_STATUS, "Launcher unregistered")
+        }
+    }
 
     fun checkAvailability() {
 
@@ -33,19 +68,7 @@ class UpdaterService(
                     Timber.d("Update available")
                     crashlytics.setCustomKey(FIREBASE_LQCH_UPDATER_STATUS, "Update available")
 
-                    try {
-                        manager.startUpdateFlowForResult(
-                            appUpdateInfo,
-                            activityResultLauncher,
-                            AppUpdateOptions.newBuilder(AppUpdateType.IMMEDIATE).build()
-                        )
-                    } catch (e: SendIntentException) {
-                        Timber.e("Update intent failed")
-                        crashlytics.setCustomKey(
-                            FIREBASE_LQCH_UPDATER_STATUS,
-                            "Update intent failed"
-                        )
-                    }
+                    launchUpdate(appUpdateInfo)
                 }
 
                 else -> {
@@ -62,8 +85,6 @@ class UpdaterService(
 
     fun resumeUpdater() {
 
-        val crashlytics = Firebase.crashlytics
-
         manager
             .appUpdateInfo
             .addOnSuccessListener { appUpdateInfo ->
@@ -71,20 +92,7 @@ class UpdaterService(
                 if (appUpdateInfo.updateAvailability()
                     == UpdateAvailability.DEVELOPER_TRIGGERED_UPDATE_IN_PROGRESS
                 ) {
-                    try {
-                        manager.startUpdateFlowForResult(
-                            appUpdateInfo,
-                            activityResultLauncher,
-                            AppUpdateOptions.newBuilder(AppUpdateType.IMMEDIATE).build()
-                        )
-                    } catch (e: SendIntentException) {
-                        Timber.e(e, "onResume updater failed")
-                        crashlytics.setCustomKey(
-                            FIREBASE_LQCH_UPDATER_STATUS,
-                            "onResume updater failed"
-                        )
-
-                    }
+                    launchUpdate(appUpdateInfo)
                 }
             }
     }

--- a/app/src/main/java/cl/figonzal/lastquakechile/core/services/notifications/QuakeNotificationImpl.kt
+++ b/app/src/main/java/cl/figonzal/lastquakechile/core/services/notifications/QuakeNotificationImpl.kt
@@ -216,11 +216,6 @@ class QuakeNotificationImpl(
             .setAutoCancel(true)
             .setVisibility(VISIBILITY_PUBLIC)
             .setContentIntent(pendingIntent)
-            .addAction(
-                R.drawable.quakes_24dp,
-                context.getString(R.string.view_quake_notification_button),
-                pendingIntent
-            )
             .run {
 
                 if (quake.greaterThan(minMagnitude) && (quake.isVerified || preliminaryNotifications)) {

--- a/app/src/main/java/cl/figonzal/lastquakechile/core/utils/views/ViewsExt.kt
+++ b/app/src/main/java/cl/figonzal/lastquakechile/core/utils/views/ViewsExt.kt
@@ -30,7 +30,10 @@ import cl.figonzal.lastquakechile.core.utils.views.*
 import cl.figonzal.lastquakechile.databinding.FragmentMapsBinding
 import cl.figonzal.lastquakechile.quake_feature.domain.model.Coordinate
 import cl.figonzal.lastquakechile.quake_feature.domain.model.Quake
-import coil.load
+import coil3.load
+import coil3.request.crossfade
+import coil3.request.error
+import coil3.request.placeholder
 import com.google.android.gms.maps.GoogleMap
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.card.MaterialCardView

--- a/app/src/main/java/cl/figonzal/lastquakechile/quake_feature/ui/QuakeDetailsActivity.kt
+++ b/app/src/main/java/cl/figonzal/lastquakechile/quake_feature/ui/QuakeDetailsActivity.kt
@@ -1,5 +1,6 @@
 package cl.figonzal.lastquakechile.quake_feature.ui
 
+import android.app.NotificationManager
 import android.animation.IntEvaluator
 import android.animation.ValueAnimator
 import android.annotation.SuppressLint
@@ -109,6 +110,10 @@ class QuakeDetailsActivity : AppCompatActivity(), OnMapReadyCallback {
                 else -> this?.get(QUAKE) as Quake
             }
             isSnapshotRequest = this?.getBoolean(IS_SNAPSHOT_REQUEST_FROM_BOTTOM_SHEET, false) ?: false
+        }
+
+        quake?.let {
+            (getSystemService(NOTIFICATION_SERVICE) as NotificationManager).cancel(it.quakeCode)
         }
 
         setTextViews()

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -106,7 +106,6 @@
     <string name="swipe_left">Swipe left to see earthquakes</string>
     <string name="local_copy">Showing local copy</string>
     <string name="cd_swipe_left_icon">Left icon</string>
-    <string name="view_quake_notification_button">See earthquake</string>
     <string name="shortcut_short_map_label">Quakes map</string>
     <string name="shortcut_long_map_label">Last quakes map</string>
     <string name="shortcut_map_disabled">Map disabled</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -107,7 +107,6 @@
     <string name="swipe_left">Desliza a la izquierda para ver sismos</string>
     <string name="local_copy">Mostrando copia local</string>
     <string name="cd_swipe_left_icon">Icono izquierda</string>
-    <string name="view_quake_notification_button">Ver sismo</string>
     <string name="shortcut_short_map_label">Mapa sismos</string>
     <string name="shortcut_long_map_label">Mapa últimos sismos</string>
     <string name="shortcut_map_disabled">Mapa deshabilitado</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -143,7 +143,6 @@
     <string name="swipe_left">Swipe left to see earthquakes</string>
     <string name="local_copy">Showing local copy</string>
     <string name="cd_swipe_left_icon">Left icon</string>
-    <string name="view_quake_notification_button">See earthquake</string>
     <string name="shortcut_short_map_label">Quakes map</string>
     <string name="shortcut_long_map_label">Last quakes map</string>
     <string name="shortcut_map_disabled">Map disabled</string>

--- a/fastlane/metadata/android/en-US/changelogs/default.txt
+++ b/fastlane/metadata/android/en-US/changelogs/default.txt
@@ -1,0 +1,2 @@
+• Improvements to earthquake notifications.
+• Stability improvements.

--- a/fastlane/metadata/android/es-419/changelogs/default.txt
+++ b/fastlane/metadata/android/es-419/changelogs/default.txt
@@ -1,0 +1,2 @@
+• Mejoras en las notificaciones de sismos.
+• Se mejoró la estabilidad del proceso de la aplicacion.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 agp = "9.2.1"
-coil = "2.7.0"
+coil = "3.4.0"
 # sept. 2024 (NO ACTUALIZAR)
 espresso = "3.7.0"
 espresso-contrib = "3.7.0"
@@ -40,7 +40,7 @@ sandwich-retrofit = { module = "com.github.skydoves:sandwich-retrofit", version.
 moshi = { module = "com.squareup.moshi:moshi", version.ref = "moshi" }
 moshi-kotlin-codegen = { module = "com.squareup.moshi:moshi-kotlin-codegen", version.ref = "moshi" }
 # Coil
-coil = { module = "io.coil-kt:coil", version.ref = "coil" }
+coil = { module = "io.coil-kt.coil3:coil", version.ref = "coil" }
 # Koin
 koin-android = { module = "io.insert-koin:koin-android", version.ref = "koin" }
 # Firebase


### PR DESCRIPTION
## Summary

- **chore**: Migración de Coil 2.7.0 → 3.4.0
- **fix**: Eliminar meta-data de Facebook SDK (ApplicationId/ClientToken) del manifest
- **fix**: Proteger el flujo de actualización in-app contra ActivityResultLauncher no registrado
- **fix**: Cancelar explícitamente la notificación en QuakeDetailsActivity al iniciar
- **fix**: Eliminar botón de acción "ver terremoto" de la notificación de sismo
- **docs**: Refactorizar README y eliminar badge de Snyk
- **docs**: Agregar comando personalizado de Claude `fastlane-changelog`

## Test plan

- [x] Verificar que las imágenes cargan correctamente con Coil v3
- [x] Probar el flujo de actualización in-app sin crashes
- [x] Verificar que las notificaciones se cancelan al abrir `QuakeDetailsActivity`
- [x] Confirmar que las notificaciones no muestran el botón de acción "ver terremoto"
- [x] Revisar que el manifest no incluye meta-data de Facebook SDK

🤖 Generated with [Claude Code](https://claude.com/claude-code)