### PR TITLE
fix: FCM notification permission and channel fixes for Android 13+

### DIFF
--- a/.agents/skills/android-architecture-clean/SKILL.md
+++ b/.agents/skills/android-architecture-clean/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: "android-architecture-clean"
+description: "Apply clean architecture boundaries, use cases, repositories, and lifecycle-aware presentation models in Android projects."
+metadata:
+  version: "0.1.0"
+  category: "foundations"
+  tags: ["android", "architecture", "clean-architecture", "layers"]
+  triggers:
+    include: ["clean architecture in android", "split use cases and repositories", "untangle presentation and data layer", "android architecture cleanup", "mvvm to cleaner boundaries"]
+    exclude: ["retrofit config only", "compose animation tweak", "play store release only"]
+  owners: ["@android-agent-skills/maintainers"]
+  test_targets: ["examples/orbittasks-compose", "examples/orbittasks-xml", "benchmarks/triggers.jsonl"]
+---
+
+# Android Architecture Clean
+
+## When To Use
+
+- Use this skill when the request is about: clean architecture in android, split use cases and
+  repositories, untangle presentation and data layer.
+- Primary outcome: Apply clean architecture boundaries, use cases, repositories, and lifecycle-aware
+  presentation models in Android projects.
+- Handoff skills when the scope expands:
+- `android-modularization`
+- `android-state-management`
+
+## Workflow
+
+1. Map the request to the current Android stack, module boundaries, and minimum supported API level.
+2. Inspect the existing implementation for implicit assumptions, duplicate helpers, and outdated
+   patterns.
+3. Apply the smallest change that improves correctness, readability, and long-term maintainability.
+4. Validate the result against the relevant showcase app path and repo benchmarks.
+5. Hand off adjacent work to the next specialized skill only after the core foundation is stable.
+
+## Guardrails
+
+- Prefer official Android and Kotlin guidance over custom local conventions when they conflict.
+- Keep public APIs boring and explicit; avoid clever abstractions that hide Android lifecycle costs.
+- Do not mix architectural cleanup with product behavior changes unless the request explicitly needs
+  both.
+- Document any compatibility constraints that will affect old modules or generated code.
+
+## Anti-Patterns
+
+- Sprinkling helpers across modules without a clear ownership boundary.
+- Introducing framework-specific code into pure domain or data layers.
+- Refactoring every adjacent file when only one contract needed to change.
+- Leaving migration notes implied instead of writing them down.
+
+## Examples
+
+### Happy path
+
+- Scenario: Separate OrbitTasks feature state, use case, and repository contracts.
+- Command: `cd examples/orbittasks-compose && ./gradlew :app:testDebugUnitTest`
+
+### Edge case
+
+- Scenario: Keep XML activity actions thin while preserving saved-state behavior.
+- Command: `cd examples/orbittasks-xml && ./gradlew :app:testDebugUnitTest`
+
+### Failure recovery
+
+- Scenario: Catch trigger confusion against modularization and state-management requests.
+- Command: `python3 scripts/eval_triggers.py --skill android-architecture-clean`
+
+## Done Checklist
+
+- The implementation path is explicit, minimal, and tied to the right Android surface.
+- Relevant example commands and benchmark prompts have been exercised or updated.
+- Handoffs to adjacent skills are documented when the request crosses boundaries.
+- Official references cover the chosen pattern and the main migration or troubleshooting path.
+
+## Official References
+
+- [https://developer.android.com/topic/architecture](https://developer.android.com/topic/architecture)
+- [https://developer.android.com/topic/architecture/recommendations](https://developer.android.com/topic/architecture/recommendations)
+- [https://developer.android.com/jetpack/guide](https://developer.android.com/jetpack/guide)
+- [https://developer.android.com/topic/libraries/architecture/viewmodel](https://developer.android.com/topic/libraries/architecture/viewmodel)

--- a/.agents/skills/android-architecture-clean/agents/openai.yaml
+++ b/.agents/skills/android-architecture-clean/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Android Architecture Clean"
+  short_description: "Apply clean architecture boundaries, use cases, repositories, and lifecycle-aware presentation models in Android projects"
+  default_prompt: "Use $android-architecture-clean when the request is about apply clean architecture boundaries, use cases, repositories, and lifecycle-aware presentation models in Android projects."

--- a/.agents/skills/android-architecture-clean/references/official-links.md
+++ b/.agents/skills/android-architecture-clean/references/official-links.md
@@ -1,0 +1,6 @@
+# Android Architecture Clean Official Links
+
+- [https://developer.android.com/topic/architecture](https://developer.android.com/topic/architecture)
+- [https://developer.android.com/topic/architecture/recommendations](https://developer.android.com/topic/architecture/recommendations)
+- [https://developer.android.com/jetpack/guide](https://developer.android.com/jetpack/guide)
+- [https://developer.android.com/topic/libraries/architecture/viewmodel](https://developer.android.com/topic/libraries/architecture/viewmodel)

--- a/.agents/skills/android-architecture-clean/references/patterns.md
+++ b/.agents/skills/android-architecture-clean/references/patterns.md
@@ -1,0 +1,23 @@
+# Android Architecture Clean Patterns
+
+## Selection Notes
+
+- Category: `foundations`
+- Best fit when the request matches the trigger language in `SKILL.md` and the implementation focus
+  is
+  `Apply clean architecture boundaries, use cases, repositories, and lifecycle-aware presentation models in Android projects.`
+- Reach for neighboring skills only after this skill has framed the main problem.
+
+## Default Review Sequence
+
+1. Map the request to the current Android stack, module boundaries, and minimum supported API level.
+2. Inspect the existing implementation for implicit assumptions, duplicate helpers, and outdated
+   patterns.
+3. Apply the smallest change that improves correctness, readability, and long-term maintainability.
+4. Validate the result against the relevant showcase app path and repo benchmarks.
+5. Hand off adjacent work to the next specialized skill only after the core foundation is stable.
+
+## Handoff Shortlist
+
+- `android-modularization`
+- `android-state-management`

--- a/.agents/skills/android-architecture-clean/references/scenarios.md
+++ b/.agents/skills/android-architecture-clean/references/scenarios.md
@@ -1,0 +1,16 @@
+# Android Architecture Clean Runnable Scenarios
+
+## Happy path
+
+- Goal: Separate OrbitTasks feature state, use case, and repository contracts.
+- Command: `cd examples/orbittasks-compose && ./gradlew :app:testDebugUnitTest`
+
+## Edge case
+
+- Goal: Keep XML activity actions thin while preserving saved-state behavior.
+- Command: `cd examples/orbittasks-xml && ./gradlew :app:testDebugUnitTest`
+
+## Failure recovery
+
+- Goal: Catch trigger confusion against modularization and state-management requests.
+- Command: `python3 scripts/eval_triggers.py --skill android-architecture-clean`

--- a/.agents/skills/android-architecture-clean/scripts/run_examples.sh
+++ b/.agents/skills/android-architecture-clean/scripts/run_examples.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+    set -euo pipefail
+
+    cat <<'EOF'
+    Skill: Android Architecture Clean
+    Canonical path: skills/android-architecture-clean
+    Example commands:
+    Happy path: cd examples/orbittasks-compose && ./gradlew :app:testDebugUnitTest
+Edge case: cd examples/orbittasks-xml && ./gradlew :app:testDebugUnitTest
+Failure recovery: python3 scripts/eval_triggers.py --skill android-architecture-clean
+    EOF

--- a/.agents/skills/android-compose-foundations/SKILL.md
+++ b/.agents/skills/android-compose-foundations/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: "android-compose-foundations"
+description: "Build Android UI with Jetpack Compose foundations, layouts, modifiers, theming, and stable component structure."
+metadata:
+  version: "0.1.0"
+  category: "ui"
+  tags: ["android", "compose", "ui", "foundation"]
+  triggers:
+    include: ["jetpack compose screen", "compose layout in android", "modifier cleanup compose", "android compose component structure", "compose foundation best practices"]
+    exclude: ["xml fragment problem", "retrofit interceptor", "play release pipeline"]
+  owners: ["@android-agent-skills/maintainers"]
+  test_targets: ["examples/orbittasks-compose", "examples/orbittasks-xml", "benchmarks/triggers.jsonl"]
+---
+
+# Android Compose Foundations
+
+## When To Use
+
+- Use this skill when the request is about: jetpack compose screen, compose layout in android,
+  modifier cleanup compose.
+- Primary outcome: Build Android UI with Jetpack Compose foundations, layouts, modifiers, theming,
+  and stable component structure.
+- Handoff skills when the scope expands:
+- `android-compose-state-effects`
+- `android-material3-design-system`
+
+## Workflow
+
+1. Identify whether the target surface is Compose, View system, or a mixed interoperability screen.
+2. Select the lowest-friction UI pattern that satisfies responsiveness, accessibility, and
+   performance needs.
+3. Build the UI around stable state, explicit side effects, and reusable design tokens.
+4. Exercise edge cases such as long text, font scaling, RTL, and narrow devices in the fixture apps.
+5. Validate with unit, UI, and screenshot-friendly checks before handing off.
+
+## Guardrails
+
+- Optimize for stable state and predictable rendering before adding animation or abstraction.
+- Respect accessibility semantics, contrast, focus order, and touch target guidance by default.
+- Do not mix Compose and View system ownership without an explicit interoperability boundary.
+- Prefer measured performance work over premature micro-optimizations.
+
+## Anti-Patterns
+
+- Embedding navigation or business logic directly in leaf UI components.
+- Using fixed dimensions that break on localization or dynamic text.
+- Ignoring semantics and announcing only visual changes.
+- Porting XML patterns directly into Compose without adapting the mental model.
+
+## Examples
+
+### Happy path
+
+- Scenario: Refine the Compose OrbitTasks board with stable slots and theme tokens.
+- Command: `cd examples/orbittasks-compose && ./gradlew :app:testDebugUnitTest`
+
+### Edge case
+
+- Scenario: Keep previews and layout behavior stable under narrow widths and long text.
+- Command: `cd examples/orbittasks-compose && ./gradlew :app:assembleDebug`
+
+### Failure recovery
+
+- Scenario: Keep general Compose requests from drifting into state/effects or performance work.
+- Command: `python3 scripts/eval_triggers.py --skill android-compose-foundations`
+
+## Done Checklist
+
+- The implementation path is explicit, minimal, and tied to the right Android surface.
+- Relevant example commands and benchmark prompts have been exercised or updated.
+- Handoffs to adjacent skills are documented when the request crosses boundaries.
+- Official references cover the chosen pattern and the main migration or troubleshooting path.
+
+## Official References
+
+- [https://developer.android.com/develop/ui/compose](https://developer.android.com/develop/ui/compose)
+- [https://developer.android.com/develop/ui/compose/layouts/basics](https://developer.android.com/develop/ui/compose/layouts/basics)
+- [https://developer.android.com/develop/ui/compose/modifiers](https://developer.android.com/develop/ui/compose/modifiers)
+- [https://developer.android.com/develop/ui/compose/designsystems/material3](https://developer.android.com/develop/ui/compose/designsystems/material3)

--- a/.agents/skills/android-compose-foundations/agents/openai.yaml
+++ b/.agents/skills/android-compose-foundations/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Android Compose Foundations"
+  short_description: "Build Android UI with Jetpack Compose foundations, layouts, modifiers, theming, and stable component structure"
+  default_prompt: "Use $android-compose-foundations when the request is about build Android UI with Jetpack Compose foundations, layouts, modifiers, theming, and stable component structure."

--- a/.agents/skills/android-compose-foundations/references/official-links.md
+++ b/.agents/skills/android-compose-foundations/references/official-links.md
@@ -1,0 +1,6 @@
+# Android Compose Foundations Official Links
+
+- [https://developer.android.com/develop/ui/compose](https://developer.android.com/develop/ui/compose)
+- [https://developer.android.com/develop/ui/compose/layouts/basics](https://developer.android.com/develop/ui/compose/layouts/basics)
+- [https://developer.android.com/develop/ui/compose/modifiers](https://developer.android.com/develop/ui/compose/modifiers)
+- [https://developer.android.com/develop/ui/compose/designsystems/material3](https://developer.android.com/develop/ui/compose/designsystems/material3)

--- a/.agents/skills/android-compose-foundations/references/patterns.md
+++ b/.agents/skills/android-compose-foundations/references/patterns.md
@@ -1,0 +1,23 @@
+# Android Compose Foundations Patterns
+
+## Selection Notes
+
+- Category: `ui`
+- Best fit when the request matches the trigger language in `SKILL.md` and the implementation focus
+  is
+  `Build Android UI with Jetpack Compose foundations, layouts, modifiers, theming, and stable component structure.`
+- Reach for neighboring skills only after this skill has framed the main problem.
+
+## Default Review Sequence
+
+1. Identify whether the target surface is Compose, View system, or a mixed interoperability screen.
+2. Select the lowest-friction UI pattern that satisfies responsiveness, accessibility, and
+   performance needs.
+3. Build the UI around stable state, explicit side effects, and reusable design tokens.
+4. Exercise edge cases such as long text, font scaling, RTL, and narrow devices in the fixture apps.
+5. Validate with unit, UI, and screenshot-friendly checks before handing off.
+
+## Handoff Shortlist
+
+- `android-compose-state-effects`
+- `android-material3-design-system`

--- a/.agents/skills/android-compose-foundations/references/scenarios.md
+++ b/.agents/skills/android-compose-foundations/references/scenarios.md
@@ -1,0 +1,16 @@
+# Android Compose Foundations Runnable Scenarios
+
+## Happy path
+
+- Goal: Refine the Compose OrbitTasks board with stable slots and theme tokens.
+- Command: `cd examples/orbittasks-compose && ./gradlew :app:testDebugUnitTest`
+
+## Edge case
+
+- Goal: Keep previews and layout behavior stable under narrow widths and long text.
+- Command: `cd examples/orbittasks-compose && ./gradlew :app:assembleDebug`
+
+## Failure recovery
+
+- Goal: Keep general Compose requests from drifting into state/effects or performance work.
+- Command: `python3 scripts/eval_triggers.py --skill android-compose-foundations`

--- a/.agents/skills/android-compose-foundations/scripts/run_examples.sh
+++ b/.agents/skills/android-compose-foundations/scripts/run_examples.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+    set -euo pipefail
+
+    cat <<'EOF'
+    Skill: Android Compose Foundations
+    Canonical path: skills/android-compose-foundations
+    Example commands:
+    Happy path: cd examples/orbittasks-compose && ./gradlew :app:testDebugUnitTest
+Edge case: cd examples/orbittasks-compose && ./gradlew :app:assembleDebug
+Failure recovery: python3 scripts/eval_triggers.py --skill android-compose-foundations
+    EOF

--- a/.agents/skills/android-coroutines-flow/SKILL.md
+++ b/.agents/skills/android-coroutines-flow/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: "android-coroutines-flow"
+description: "Use coroutines, Flow, structured concurrency, dispatchers, and cancellation-safe Android async pipelines."
+metadata:
+  version: "0.1.0"
+  category: "foundations"
+  tags: ["android", "coroutines", "flow", "async"]
+  triggers:
+    include: ["android flow collection", "fix coroutine scope in android", "structured concurrency in viewmodel", "flow retry caching android", "dispatcher cleanup in android"]
+    exclude: ["play release notes", "xml layout spacing", "hilt module graph only"]
+  owners: ["@android-agent-skills/maintainers"]
+  test_targets: ["examples/orbittasks-compose", "examples/orbittasks-xml", "benchmarks/triggers.jsonl"]
+---
+
+# Android Coroutines Flow
+
+## When To Use
+
+- Use this skill when the request is about: android flow collection, fix coroutine scope in android,
+  structured concurrency in viewmodel.
+- Primary outcome: Use coroutines, Flow, structured concurrency, dispatchers, and cancellation-safe
+  Android async pipelines.
+- Handoff skills when the scope expands:
+- `android-state-management`
+- `android-workmanager-notifications`
+
+## Workflow
+
+1. Map the request to the current Android stack, module boundaries, and minimum supported API level.
+2. Inspect the existing implementation for implicit assumptions, duplicate helpers, and outdated
+   patterns.
+3. Apply the smallest change that improves correctness, readability, and long-term maintainability.
+4. Validate the result against the relevant showcase app path and repo benchmarks.
+5. Hand off adjacent work to the next specialized skill only after the core foundation is stable.
+
+## Guardrails
+
+- Prefer official Android and Kotlin guidance over custom local conventions when they conflict.
+- Keep public APIs boring and explicit; avoid clever abstractions that hide Android lifecycle costs.
+- Do not mix architectural cleanup with product behavior changes unless the request explicitly needs
+  both.
+- Document any compatibility constraints that will affect old modules or generated code.
+
+## Anti-Patterns
+
+- Sprinkling helpers across modules without a clear ownership boundary.
+- Introducing framework-specific code into pure domain or data layers.
+- Refactoring every adjacent file when only one contract needed to change.
+- Leaving migration notes implied instead of writing them down.
+
+## Remediation Examples
+
+### Inject dispatchers instead of hard-coding them
+
+```kotlin
+class TaskRepository(
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+) {
+    suspend fun refresh(): List<TaskUiModel> = withContext(ioDispatcher) { loadTasks() }
+}
+```
+
+### Collect flows with lifecycle awareness
+
+```kotlin
+viewLifecycleOwner.lifecycleScope.launch {
+    viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+        viewModel.uiState.collect { render(it) }
+    }
+}
+```
+
+### Preserve cancellation in generic error handling
+
+```kotlin
+try {
+    repository.refresh()
+} catch (error: CancellationException) {
+    throw error
+} catch (error: Exception) {
+    emit(UiState.Error(error))
+}
+```
+
+## Examples
+
+### Happy path
+
+- Scenario: Model task updates as StateFlow and shared event channels in the Compose fixture.
+- Command: `cd examples/orbittasks-compose && ./gradlew :app:testDebugUnitTest`
+
+### Edge case
+
+- Scenario: Recover from cancellation and configuration changes in the XML activity flow.
+- Command: `cd examples/orbittasks-xml && ./gradlew :app:testDebugUnitTest`
+
+### Failure recovery
+
+- Scenario: Disambiguate coroutine requests from state-management and WorkManager prompts.
+- Command: `python3 scripts/eval_triggers.py --skill android-coroutines-flow`
+
+## Done Checklist
+
+- The implementation path is explicit, minimal, and tied to the right Android surface.
+- Relevant example commands and benchmark prompts have been exercised or updated.
+- Handoffs to adjacent skills are documented when the request crosses boundaries.
+- Official references cover the chosen pattern and the main migration or troubleshooting path.
+
+## Official References
+
+- [https://developer.android.com/kotlin/coroutines](https://developer.android.com/kotlin/coroutines)
+- [https://developer.android.com/topic/libraries/architecture/coroutines](https://developer.android.com/topic/libraries/architecture/coroutines)
+- [https://kotlinlang.org/docs/coroutines-overview.html](https://kotlinlang.org/docs/coroutines-overview.html)
+- [https://kotlinlang.org/docs/flow.html](https://kotlinlang.org/docs/flow.html)

--- a/.agents/skills/android-coroutines-flow/agents/openai.yaml
+++ b/.agents/skills/android-coroutines-flow/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Android Coroutines Flow"
+  short_description: "Use coroutines, Flow, structured concurrency, dispatchers, and cancellation-safe Android async pipelines"
+  default_prompt: "Use $android-coroutines-flow when the request is about use coroutines, Flow, structured concurrency, dispatchers, and cancellation-safe Android async pipelines."

--- a/.agents/skills/android-coroutines-flow/references/official-links.md
+++ b/.agents/skills/android-coroutines-flow/references/official-links.md
@@ -1,0 +1,6 @@
+# Android Coroutines Flow Official Links
+
+- [https://developer.android.com/kotlin/coroutines](https://developer.android.com/kotlin/coroutines)
+- [https://developer.android.com/topic/libraries/architecture/coroutines](https://developer.android.com/topic/libraries/architecture/coroutines)
+- [https://kotlinlang.org/docs/coroutines-overview.html](https://kotlinlang.org/docs/coroutines-overview.html)
+- [https://kotlinlang.org/docs/flow.html](https://kotlinlang.org/docs/flow.html)

--- a/.agents/skills/android-coroutines-flow/references/patterns.md
+++ b/.agents/skills/android-coroutines-flow/references/patterns.md
@@ -1,0 +1,23 @@
+# Android Coroutines Flow Patterns
+
+## Selection Notes
+
+- Category: `foundations`
+- Best fit when the request matches the trigger language in `SKILL.md` and the implementation focus
+  is
+  `Use coroutines, Flow, structured concurrency, dispatchers, and cancellation-safe Android async pipelines.`
+- Reach for neighboring skills only after this skill has framed the main problem.
+
+## Default Review Sequence
+
+1. Map the request to the current Android stack, module boundaries, and minimum supported API level.
+2. Inspect the existing implementation for implicit assumptions, duplicate helpers, and outdated
+   patterns.
+3. Apply the smallest change that improves correctness, readability, and long-term maintainability.
+4. Validate the result against the relevant showcase app path and repo benchmarks.
+5. Hand off adjacent work to the next specialized skill only after the core foundation is stable.
+
+## Handoff Shortlist
+
+- `android-state-management`
+- `android-workmanager-notifications`

--- a/.agents/skills/android-coroutines-flow/references/scenarios.md
+++ b/.agents/skills/android-coroutines-flow/references/scenarios.md
@@ -1,0 +1,16 @@
+# Android Coroutines Flow Runnable Scenarios
+
+## Happy path
+
+- Goal: Model task updates as StateFlow and shared event channels in the Compose fixture.
+- Command: `cd examples/orbittasks-compose && ./gradlew :app:testDebugUnitTest`
+
+## Edge case
+
+- Goal: Recover from cancellation and configuration changes in the XML activity flow.
+- Command: `cd examples/orbittasks-xml && ./gradlew :app:testDebugUnitTest`
+
+## Failure recovery
+
+- Goal: Disambiguate coroutine requests from state-management and WorkManager prompts.
+- Command: `python3 scripts/eval_triggers.py --skill android-coroutines-flow`

--- a/.agents/skills/android-coroutines-flow/scripts/run_examples.sh
+++ b/.agents/skills/android-coroutines-flow/scripts/run_examples.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+    set -euo pipefail
+
+    cat <<'EOF'
+    Skill: Android Coroutines Flow
+    Canonical path: skills/android-coroutines-flow
+    Example commands:
+    Happy path: cd examples/orbittasks-compose && ./gradlew :app:testDebugUnitTest
+Edge case: cd examples/orbittasks-xml && ./gradlew :app:testDebugUnitTest
+Failure recovery: python3 scripts/eval_triggers.py --skill android-coroutines-flow
+    EOF

--- a/.agents/skills/android-di-hilt/SKILL.md
+++ b/.agents/skills/android-di-hilt/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: "android-di-hilt"
+description: "Wire Android dependency injection with Hilt, scopes, testing overrides, and module ownership boundaries."
+metadata:
+  version: "0.1.0"
+  category: "foundations"
+  tags: ["android", "hilt", "dependency-injection", "testing"]
+  triggers:
+    include: ["android hilt setup", "inject viewmodel repository hilt", "scope dependency in android", "replace manual service locator", "hilt testing override", "android-di-hilt skill", "scope dependency in android hilt", "hilt component scope mismatch", "hilt entry point android"]
+    exclude: ["retrofit serialization only", "compose typography only", "gradle wrapper upgrade", "collect flow in compose screen", "state matrix before release"]
+  owners: ["@android-agent-skills/maintainers"]
+  test_targets: ["examples/orbittasks-compose", "examples/orbittasks-xml", "benchmarks/triggers.jsonl"]
+---
+
+# Android DI Hilt
+
+## When To Use
+
+- Use this skill when the request is about: android hilt setup, inject viewmodel repository hilt,
+  scope dependency in android.
+- Primary outcome: Wire Android dependency injection with Hilt, scopes, testing overrides, and
+  module ownership boundaries.
+- Reach for this skill when the hard part is component ownership, bindings, scopes, entry points, or
+  test replacement. If the request is only about networking APIs or reducer design, use the
+  neighboring skill instead.
+- Handoff skills when the scope expands:
+- `android-testing-unit`
+- `android-networking-retrofit-okhttp`
+
+## Workflow
+
+1. Identify the injection boundary first: app-wide singleton, activity-retained, ViewModel, worker,
+   service, or entry point from unsupported framework code.
+2. Decide what should be bound: constructor injection, `@Binds`, `@Provides`, qualifiers,
+   multibindings, or assisted injection.
+3. Match lifetime to scope explicitly so dependencies do not outlive their owner or rebuild too
+   often.
+4. Verify replacement strategy for tests with Hilt test modules, uninstall modules, or fakes at the
+   right component boundary.
+5. Hand off API-specific or architectural questions only after the DI graph ownership is correct.
+
+## Guardrails
+
+- Prefer constructor injection for app code you own.
+- Use qualifiers and scope annotations deliberately; ambiguous bindings are a graph smell, not a
+  convenience.
+- Keep Hilt modules close to the ownership boundary they configure.
+- Treat test replacement as part of the design, not an afterthought.
+
+## Anti-Patterns
+
+- Making everything `@Singleton` to silence scope questions.
+- Hiding business construction logic inside giant `@Provides` methods when constructor injection
+  would suffice.
+- Using Hilt modules as a dumping ground for unrelated bindings across modules.
+- Confusing DI graph ownership with app architecture ownership.
+
+## Review Focus
+
+- Component and scope alignment.
+- Binding style and qualifier clarity.
+- Unsupported-entry-point bridges and test replacement strategy.
+- Module ownership boundaries across features and core code.
+
+## Examples
+
+### Happy path
+
+- Scenario: Inject OrbitTasks repositories and dispatchers with clear Hilt scopes.
+- Command: `cd examples/orbittasks-compose && ./gradlew :app:testDebugUnitTest`
+
+### Edge case
+
+- Scenario: Swap fake dependencies in the XML fixture for deterministic tests.
+- Command: `cd examples/orbittasks-xml && ./gradlew :app:testDebugUnitTest`
+
+### Failure recovery
+
+- Scenario: Catch DI-specific prompts before they drift into architecture-clean or networking.
+- Command: `python3 scripts/eval_triggers.py --skill android-di-hilt`
+
+## Done Checklist
+
+- Component lifetime matches dependency lifetime.
+- Binding style is explicit and testable.
+- Test overrides or fakes are planned at the right graph boundary.
+- Non-DI work is handed off instead of buried in modules.
+
+## Official References
+
+- [https://developer.android.com/training/dependency-injection/hilt-android](https://developer.android.com/training/dependency-injection/hilt-android)
+- [https://developer.android.com/training/dependency-injection/hilt-testing](https://developer.android.com/training/dependency-injection/hilt-testing)
+- [https://developer.android.com/training/dependency-injection/hilt-multi-module](https://developer.android.com/training/dependency-injection/hilt-multi-module)
+- [https://developer.android.com/topic/libraries/architecture/viewmodel](https://developer.android.com/topic/libraries/architecture/viewmodel)
+- [https://developer.android.com/training/dependency-injection/manual](https://developer.android.com/training/dependency-injection/manual)

--- a/.agents/skills/android-di-hilt/agents/openai.yaml
+++ b/.agents/skills/android-di-hilt/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Android DI Hilt"
+  short_description: "Wire Android dependency injection with Hilt, scopes, testing overrides, and module ownership boundaries"
+  default_prompt: "Use $android-di-hilt when the request is about wire Android dependency injection with Hilt, scopes, testing overrides, and module ownership boundaries."

--- a/.agents/skills/android-di-hilt/references/official-links.md
+++ b/.agents/skills/android-di-hilt/references/official-links.md
@@ -1,0 +1,7 @@
+# Android DI Hilt Official Links
+
+- [https://developer.android.com/training/dependency-injection/hilt-android](https://developer.android.com/training/dependency-injection/hilt-android)
+- [https://developer.android.com/training/dependency-injection/hilt-testing](https://developer.android.com/training/dependency-injection/hilt-testing)
+- [https://developer.android.com/training/dependency-injection/hilt-multi-module](https://developer.android.com/training/dependency-injection/hilt-multi-module)
+- [https://developer.android.com/topic/libraries/architecture/viewmodel](https://developer.android.com/topic/libraries/architecture/viewmodel)
+- [https://developer.android.com/training/dependency-injection/manual](https://developer.android.com/training/dependency-injection/manual)

--- a/.agents/skills/android-di-hilt/references/patterns.md
+++ b/.agents/skills/android-di-hilt/references/patterns.md
@@ -1,0 +1,40 @@
+# Android DI Hilt Patterns
+
+## Selection Notes
+
+- Category: `foundations`
+- Best fit when the request matches the trigger language in `SKILL.md` and the implementation focus
+  is
+  `Wire Android dependency injection with Hilt, scopes, testing overrides, and module ownership boundaries.`
+- Reach for neighboring skills only after this skill has framed the main problem.
+
+## Review Sequence
+
+- Ownership:
+  which component owns the dependency and why
+- Binding style:
+  constructor injection vs `@Binds` vs `@Provides` vs entry point
+- Lifetime:
+  singleton vs retained vs ViewModel vs shorter-lived scopes
+- Testing:
+  fake/replacement strategy and graph override location
+
+## Default Review Sequence
+
+1. Identify the injection boundary and owner component.
+2. Choose the simplest binding style that fits.
+3. Match scope to lifetime deliberately.
+4. Plan test replacement at the same graph boundary.
+5. Hand off non-DI concerns once the graph is coherent.
+
+## Best-Practice Notes
+
+- Constructor injection is the default when you control the type.
+- Qualifiers are often clearer than multiple similar providers with implicit selection.
+- Multi-module Hilt setups need explicit ownership to avoid “god modules.”
+- Scope bugs are usually ownership bugs first.
+
+## Handoff Shortlist
+
+- `android-testing-unit`
+- `android-networking-retrofit-okhttp`

--- a/.agents/skills/android-di-hilt/references/scenarios.md
+++ b/.agents/skills/android-di-hilt/references/scenarios.md
@@ -1,0 +1,18 @@
+# Android DI Hilt Runnable Scenarios
+
+## Happy path
+
+- Goal: Inject OrbitTasks repositories and dispatchers with clear Hilt scopes and explicit
+  qualifiers.
+- Command: `cd examples/orbittasks-compose && ./gradlew :app:testDebugUnitTest`
+
+## Edge case
+
+- Goal: Swap fake dependencies in the XML fixture with graph overrides at the correct component
+  boundary.
+- Command: `cd examples/orbittasks-xml && ./gradlew :app:testDebugUnitTest`
+
+## Failure recovery
+
+- Goal: Catch DI-specific prompts before they drift into architecture-clean or networking.
+- Command: `python3 scripts/eval_triggers.py --skill android-di-hilt`

--- a/.agents/skills/android-di-hilt/scripts/run_examples.sh
+++ b/.agents/skills/android-di-hilt/scripts/run_examples.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+    set -euo pipefail
+
+    cat <<'EOF'
+    Skill: Android DI Hilt
+    Canonical path: skills/android-di-hilt
+    Example commands:
+    Happy path: cd examples/orbittasks-compose && ./gradlew :app:testDebugUnitTest
+Edge case: cd examples/orbittasks-xml && ./gradlew :app:testDebugUnitTest
+Failure recovery: python3 scripts/eval_triggers.py --skill android-di-hilt
+    EOF

--- a/.agents/skills/android-gradle-build-logic/SKILL.md
+++ b/.agents/skills/android-gradle-build-logic/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: "android-gradle-build-logic"
+description: "Shape Android build logic with Gradle, version catalogs, plugins, convention patterns, and toolchain compatibility."
+metadata:
+  version: "0.1.0"
+  category: "foundations"
+  tags: ["android", "gradle", "build", "toolchain"]
+  triggers:
+    include: ["android gradle plugin setup", "fix build logic for android modules", "version catalog for android repo", "gradle convention cleanup for android", "agp build logic change"]
+    exclude: ["room schema migration only", "compose layout only", "notification permission flow"]
+  owners: ["@android-agent-skills/maintainers"]
+  test_targets: ["examples/orbittasks-compose", "examples/orbittasks-xml", "benchmarks/triggers.jsonl"]
+---
+
+# Android Gradle Build Logic
+
+## When To Use
+
+- Use this skill when the request is about: android gradle plugin setup, fix build logic for android
+  modules, version catalog for android repo.
+- Primary outcome: Shape Android build logic with Gradle, version catalogs, plugins, convention
+  patterns, and toolchain compatibility.
+- Handoff skills when the scope expands:
+- `android-modernization-upgrade`
+- `android-ci-cd-release-playstore`
+
+## Workflow
+
+1. Map the request to the current Android stack, module boundaries, and minimum supported API level.
+2. Inspect the existing implementation for implicit assumptions, duplicate helpers, and outdated
+   patterns.
+3. Apply the smallest change that improves correctness, readability, and long-term maintainability.
+4. Validate the result against the relevant showcase app path and repo benchmarks.
+5. Hand off adjacent work to the next specialized skill only after the core foundation is stable.
+
+## Guardrails
+
+- Prefer official Android and Kotlin guidance over custom local conventions when they conflict.
+- Keep public APIs boring and explicit; avoid clever abstractions that hide Android lifecycle costs.
+- Do not mix architectural cleanup with product behavior changes unless the request explicitly needs
+  both.
+- Document any compatibility constraints that will affect old modules or generated code.
+
+## Anti-Patterns
+
+- Sprinkling helpers across modules without a clear ownership boundary.
+- Introducing framework-specific code into pure domain or data layers.
+- Refactoring every adjacent file when only one contract needed to change.
+- Leaving migration notes implied instead of writing them down.
+
+## Examples
+
+### Happy path
+
+- Scenario: Run the Compose showcase build from a clean checkout with version catalogs.
+- Command: `cd examples/orbittasks-compose && ./gradlew :app:assembleDebug`
+
+### Edge case
+
+- Scenario: Validate shared repositories and plugin management in the XML fixture.
+- Command: `cd examples/orbittasks-xml && ./gradlew :app:assembleDebug`
+
+### Failure recovery
+
+- Scenario: Benchmark build-logic trigger precision against modernization and CI skills.
+- Command: `python3 scripts/eval_triggers.py --skill android-gradle-build-logic`
+
+## Done Checklist
+
+- The implementation path is explicit, minimal, and tied to the right Android surface.
+- Relevant example commands and benchmark prompts have been exercised or updated.
+- Handoffs to adjacent skills are documented when the request crosses boundaries.
+- Official references cover the chosen pattern and the main migration or troubleshooting path.
+
+## Official References
+
+- [https://developer.android.com/build](https://developer.android.com/build)
+- [https://developer.android.com/build/releases/gradle-plugin](https://developer.android.com/build/releases/gradle-plugin)
+- [https://developer.android.com/build/migrate-to-built-in-kotlin](https://developer.android.com/build/migrate-to-built-in-kotlin)
+- [https://docs.gradle.org/current/userguide/userguide.html](https://docs.gradle.org/current/userguide/userguide.html)

--- a/.agents/skills/android-gradle-build-logic/agents/openai.yaml
+++ b/.agents/skills/android-gradle-build-logic/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Android Gradle Build Logic"
+  short_description: "Shape Android build logic with Gradle, version catalogs, plugins, convention patterns, and toolchain compatibility"
+  default_prompt: "Use $android-gradle-build-logic when the request is about shape Android build logic with Gradle, version catalogs, plugins, convention patterns, and toolchain compatibility."

--- a/.agents/skills/android-gradle-build-logic/references/official-links.md
+++ b/.agents/skills/android-gradle-build-logic/references/official-links.md
@@ -1,0 +1,6 @@
+# Android Gradle Build Logic Official Links
+
+- [https://developer.android.com/build](https://developer.android.com/build)
+- [https://developer.android.com/build/releases/gradle-plugin](https://developer.android.com/build/releases/gradle-plugin)
+- [https://developer.android.com/build/migrate-to-built-in-kotlin](https://developer.android.com/build/migrate-to-built-in-kotlin)
+- [https://docs.gradle.org/current/userguide/userguide.html](https://docs.gradle.org/current/userguide/userguide.html)

--- a/.agents/skills/android-gradle-build-logic/references/patterns.md
+++ b/.agents/skills/android-gradle-build-logic/references/patterns.md
@@ -1,0 +1,23 @@
+# Android Gradle Build Logic Patterns
+
+## Selection Notes
+
+- Category: `foundations`
+- Best fit when the request matches the trigger language in `SKILL.md` and the implementation focus
+  is
+  `Shape Android build logic with Gradle, version catalogs, plugins, convention patterns, and toolchain compatibility.`
+- Reach for neighboring skills only after this skill has framed the main problem.
+
+## Default Review Sequence
+
+1. Map the request to the current Android stack, module boundaries, and minimum supported API level.
+2. Inspect the existing implementation for implicit assumptions, duplicate helpers, and outdated
+   patterns.
+3. Apply the smallest change that improves correctness, readability, and long-term maintainability.
+4. Validate the result against the relevant showcase app path and repo benchmarks.
+5. Hand off adjacent work to the next specialized skill only after the core foundation is stable.
+
+## Handoff Shortlist
+
+- `android-modernization-upgrade`
+- `android-ci-cd-release-playstore`

--- a/.agents/skills/android-gradle-build-logic/references/scenarios.md
+++ b/.agents/skills/android-gradle-build-logic/references/scenarios.md
@@ -1,0 +1,16 @@
+# Android Gradle Build Logic Runnable Scenarios
+
+## Happy path
+
+- Goal: Run the Compose showcase build from a clean checkout with version catalogs.
+- Command: `cd examples/orbittasks-compose && ./gradlew :app:assembleDebug`
+
+## Edge case
+
+- Goal: Validate shared repositories and plugin management in the XML fixture.
+- Command: `cd examples/orbittasks-xml && ./gradlew :app:assembleDebug`
+
+## Failure recovery
+
+- Goal: Benchmark build-logic trigger precision against modernization and CI skills.
+- Command: `python3 scripts/eval_triggers.py --skill android-gradle-build-logic`

--- a/.agents/skills/android-gradle-build-logic/scripts/run_examples.sh
+++ b/.agents/skills/android-gradle-build-logic/scripts/run_examples.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+    set -euo pipefail
+
+    cat <<'EOF'
+    Skill: Android Gradle Build Logic
+    Canonical path: skills/android-gradle-build-logic
+    Example commands:
+    Happy path: cd examples/orbittasks-compose && ./gradlew :app:assembleDebug
+Edge case: cd examples/orbittasks-xml && ./gradlew :app:assembleDebug
+Failure recovery: python3 scripts/eval_triggers.py --skill android-gradle-build-logic
+    EOF

--- a/.agents/skills/android-kotlin-core/SKILL.md
+++ b/.agents/skills/android-kotlin-core/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: "android-kotlin-core"
+description: "Use Kotlin idioms safely in Android apps, including nullability, data classes, sealed types, extension functions, and collection pipelines."
+metadata:
+  version: "0.1.0"
+  category: "foundations"
+  tags: ["android", "kotlin", "foundation", "api-design"]
+  triggers:
+    include: ["kotlin cleanup in android app", "convert verbose android java-style kotlin", "sealed classes for ui state", "extension functions for android feature", "improve kotlin readability in android module"]
+    exclude: ["full gradle upgrade", "compose navigation only", "release play console setup"]
+  owners: ["@android-agent-skills/maintainers"]
+  test_targets: ["examples/orbittasks-compose", "examples/orbittasks-xml", "benchmarks/triggers.jsonl"]
+---
+
+# Android Kotlin Core
+
+## When To Use
+
+- Use this skill when the request is about: kotlin cleanup in android app, convert verbose android
+  java-style kotlin, sealed classes for ui state.
+- Primary outcome: Use Kotlin idioms safely in Android apps, including nullability, data classes,
+  sealed types, extension functions, and collection pipelines.
+- Handoff skills when the scope expands:
+- `android-state-management`
+- `android-testing-unit`
+
+## Workflow
+
+1. Map the request to the current Android stack, module boundaries, and minimum supported API level.
+2. Inspect the existing implementation for implicit assumptions, duplicate helpers, and outdated
+   patterns.
+3. Apply the smallest change that improves correctness, readability, and long-term maintainability.
+4. Validate the result against the relevant showcase app path and repo benchmarks.
+5. Hand off adjacent work to the next specialized skill only after the core foundation is stable.
+
+## Guardrails
+
+- Prefer official Android and Kotlin guidance over custom local conventions when they conflict.
+- Keep public APIs boring and explicit; avoid clever abstractions that hide Android lifecycle costs.
+- Do not mix architectural cleanup with product behavior changes unless the request explicitly needs
+  both.
+- Document any compatibility constraints that will affect old modules or generated code.
+
+## Anti-Patterns
+
+- Sprinkling helpers across modules without a clear ownership boundary.
+- Introducing framework-specific code into pure domain or data layers.
+- Refactoring every adjacent file when only one contract needed to change.
+- Leaving migration notes implied instead of writing them down.
+
+## Examples
+
+### Happy path
+
+- Scenario: Tighten domain and UI state models with sealed interfaces and immutable data.
+- Command: `cd examples/orbittasks-compose && ./gradlew :app:testDebugUnitTest`
+
+### Edge case
+
+- Scenario: Guard nullable platform values crossing the XML activity boundary.
+- Command: `cd examples/orbittasks-xml && ./gradlew :app:testDebugUnitTest`
+
+### Failure recovery
+
+- Scenario: Refactor broad helper objects into focused extensions without breaking call sites.
+- Command: `python3 scripts/eval_triggers.py --skill android-kotlin-core`
+
+## Done Checklist
+
+- The implementation path is explicit, minimal, and tied to the right Android surface.
+- Relevant example commands and benchmark prompts have been exercised or updated.
+- Handoffs to adjacent skills are documented when the request crosses boundaries.
+- Official references cover the chosen pattern and the main migration or troubleshooting path.
+
+## Official References
+
+- [https://developer.android.com/kotlin](https://developer.android.com/kotlin)
+- [https://developer.android.com/build/kotlin-support](https://developer.android.com/build/kotlin-support)
+- [https://kotlinlang.org/docs/coding-conventions.html](https://kotlinlang.org/docs/coding-conventions.html)
+- [https://kotlinlang.org/docs/null-safety.html](https://kotlinlang.org/docs/null-safety.html)

--- a/.agents/skills/android-kotlin-core/agents/openai.yaml
+++ b/.agents/skills/android-kotlin-core/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Android Kotlin Core"
+  short_description: "Use Kotlin idioms safely in Android apps, including nullability, data classes, sealed types, extension functions, and collection pipelines"
+  default_prompt: "Use $android-kotlin-core when the request is about use Kotlin idioms safely in Android apps, including nullability, data classes, sealed types, extension functions, and collection pipelines."

--- a/.agents/skills/android-kotlin-core/references/official-links.md
+++ b/.agents/skills/android-kotlin-core/references/official-links.md
@@ -1,0 +1,6 @@
+# Android Kotlin Core Official Links
+
+- [https://developer.android.com/kotlin](https://developer.android.com/kotlin)
+- [https://developer.android.com/build/kotlin-support](https://developer.android.com/build/kotlin-support)
+- [https://kotlinlang.org/docs/coding-conventions.html](https://kotlinlang.org/docs/coding-conventions.html)
+- [https://kotlinlang.org/docs/null-safety.html](https://kotlinlang.org/docs/null-safety.html)

--- a/.agents/skills/android-kotlin-core/references/patterns.md
+++ b/.agents/skills/android-kotlin-core/references/patterns.md
@@ -1,0 +1,23 @@
+# Android Kotlin Core Patterns
+
+## Selection Notes
+
+- Category: `foundations`
+- Best fit when the request matches the trigger language in `SKILL.md` and the implementation focus
+  is
+  `Use Kotlin idioms safely in Android apps, including nullability, data classes, sealed types, extension functions, and collection pipelines.`
+- Reach for neighboring skills only after this skill has framed the main problem.
+
+## Default Review Sequence
+
+1. Map the request to the current Android stack, module boundaries, and minimum supported API level.
+2. Inspect the existing implementation for implicit assumptions, duplicate helpers, and outdated
+   patterns.
+3. Apply the smallest change that improves correctness, readability, and long-term maintainability.
+4. Validate the result against the relevant showcase app path and repo benchmarks.
+5. Hand off adjacent work to the next specialized skill only after the core foundation is stable.
+
+## Handoff Shortlist
+
+- `android-state-management`
+- `android-testing-unit`

--- a/.agents/skills/android-kotlin-core/references/scenarios.md
+++ b/.agents/skills/android-kotlin-core/references/scenarios.md
@@ -1,0 +1,16 @@
+# Android Kotlin Core Runnable Scenarios
+
+## Happy path
+
+- Goal: Tighten domain and UI state models with sealed interfaces and immutable data.
+- Command: `cd examples/orbittasks-compose && ./gradlew :app:testDebugUnitTest`
+
+## Edge case
+
+- Goal: Guard nullable platform values crossing the XML activity boundary.
+- Command: `cd examples/orbittasks-xml && ./gradlew :app:testDebugUnitTest`
+
+## Failure recovery
+
+- Goal: Refactor broad helper objects into focused extensions without breaking call sites.
+- Command: `python3 scripts/eval_triggers.py --skill android-kotlin-core`

--- a/.agents/skills/android-kotlin-core/scripts/run_examples.sh
+++ b/.agents/skills/android-kotlin-core/scripts/run_examples.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+    set -euo pipefail
+
+    cat <<'EOF'
+    Skill: Android Kotlin Core
+    Canonical path: skills/android-kotlin-core
+    Example commands:
+    Happy path: cd examples/orbittasks-compose && ./gradlew :app:testDebugUnitTest
+Edge case: cd examples/orbittasks-xml && ./gradlew :app:testDebugUnitTest
+Failure recovery: python3 scripts/eval_triggers.py --skill android-kotlin-core
+    EOF

--- a/.agents/skills/android-networking-retrofit-okhttp/SKILL.md
+++ b/.agents/skills/android-networking-retrofit-okhttp/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: "android-networking-retrofit-okhttp"
+description: "Build Android networking stacks with Retrofit, OkHttp, interceptors, API contracts, and resilient error handling."
+metadata:
+  version: "0.1.0"
+  category: "data-platform"
+  tags: ["android", "networking", "retrofit", "okhttp"]
+  triggers:
+    include: ["retrofit android setup", "okhttp interceptor android", "api error mapping android", "network client cleanup android", "retry timeout android api"]
+    exclude: ["fragment back stack", "compose semantics", "play store notes"]
+  owners: ["@android-agent-skills/maintainers"]
+  test_targets: ["examples/orbittasks-compose", "examples/orbittasks-xml", "benchmarks/triggers.jsonl"]
+---
+
+# Android Networking Retrofit OkHttp
+
+## When To Use
+
+- Use this skill when the request is about: retrofit android setup, okhttp interceptor android, api
+  error mapping android.
+- Primary outcome: Build Android networking stacks with Retrofit, OkHttp, interceptors, API
+  contracts, and resilient error handling.
+- Handoff skills when the scope expands:
+- `android-serialization-offline-sync`
+- `android-security-best-practices`
+
+## Workflow
+
+1. Confirm the data source, persistence boundary, sync model, and device capability involved.
+2. Model contracts explicitly before wiring network, storage, media, or background APIs.
+3. Apply the recommended AndroidX or platform pattern with migration-safe defaults.
+4. Validate offline, retry, and process death behavior against the sample apps and scenarios.
+5. Escalate security, performance, or release risk to the linked supporting skills when needed.
+
+## Guardrails
+
+- Prefer typed models and explicit serializers over ad-hoc maps or bundles.
+- Keep background work idempotent and cancellation-aware.
+- Do not leak storage, media, or networking details into presentation code.
+- Treat user data durability, privacy, and migration paths as part of the implementation.
+
+## Anti-Patterns
+
+- Blocking the main thread with disk or network calls.
+- Treating retryable sync failures as terminal user-facing errors.
+- Mixing cache models and wire models without a mapping layer.
+- Requesting broad storage or notification capabilities when a narrower API exists.
+
+## Examples
+
+### Happy path
+
+- Scenario: Model sync requests and network failures for task refresh.
+- Command: `cd examples/orbittasks-compose && ./gradlew :app:testDebugUnitTest`
+
+### Edge case
+
+- Scenario: Handle stale cache and retry behavior in the XML fixture.
+- Command: `cd examples/orbittasks-xml && ./gradlew :app:testDebugUnitTest`
+
+### Failure recovery
+
+- Scenario: Differentiate networking prompts from serialization, security, and offline-sync
+  requests.
+- Command: `python3 scripts/eval_triggers.py --skill android-networking-retrofit-okhttp`
+
+## Done Checklist
+
+- The implementation path is explicit, minimal, and tied to the right Android surface.
+- Relevant example commands and benchmark prompts have been exercised or updated.
+- Handoffs to adjacent skills are documented when the request crosses boundaries.
+- Official references cover the chosen pattern and the main migration or troubleshooting path.
+
+## Official References
+
+- [https://developer.android.com/develop/connectivity/network-ops/connecting](https://developer.android.com/develop/connectivity/network-ops/connecting)
+- [https://developer.android.com/topic/architecture/data-layer/offline-first](https://developer.android.com/topic/architecture/data-layer/offline-first)
+- [https://developer.android.com/training/volley](https://developer.android.com/training/volley)
+- [https://developer.android.com/training/articles/perf-anr](https://developer.android.com/training/articles/perf-anr)

--- a/.agents/skills/android-networking-retrofit-okhttp/agents/openai.yaml
+++ b/.agents/skills/android-networking-retrofit-okhttp/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Android Networking Retrofit OkHttp"
+  short_description: "Build Android networking stacks with Retrofit, OkHttp, interceptors, API contracts, and resilient error handling"
+  default_prompt: "Use $android-networking-retrofit-okhttp when the request is about build Android networking stacks with Retrofit, OkHttp, interceptors, API contracts, and resilient error handling."

--- a/.agents/skills/android-networking-retrofit-okhttp/references/official-links.md
+++ b/.agents/skills/android-networking-retrofit-okhttp/references/official-links.md
@@ -1,0 +1,6 @@
+# Android Networking Retrofit OkHttp Official Links
+
+- [https://developer.android.com/develop/connectivity/network-ops/connecting](https://developer.android.com/develop/connectivity/network-ops/connecting)
+- [https://developer.android.com/topic/architecture/data-layer/offline-first](https://developer.android.com/topic/architecture/data-layer/offline-first)
+- [https://developer.android.com/training/volley](https://developer.android.com/training/volley)
+- [https://developer.android.com/training/articles/perf-anr](https://developer.android.com/training/articles/perf-anr)

--- a/.agents/skills/android-networking-retrofit-okhttp/references/patterns.md
+++ b/.agents/skills/android-networking-retrofit-okhttp/references/patterns.md
@@ -1,0 +1,22 @@
+# Android Networking Retrofit OkHttp Patterns
+
+## Selection Notes
+
+- Category: `data-platform`
+- Best fit when the request matches the trigger language in `SKILL.md` and the implementation focus
+  is
+  `Build Android networking stacks with Retrofit, OkHttp, interceptors, API contracts, and resilient error handling.`
+- Reach for neighboring skills only after this skill has framed the main problem.
+
+## Default Review Sequence
+
+1. Confirm the data source, persistence boundary, sync model, and device capability involved.
+2. Model contracts explicitly before wiring network, storage, media, or background APIs.
+3. Apply the recommended AndroidX or platform pattern with migration-safe defaults.
+4. Validate offline, retry, and process death behavior against the sample apps and scenarios.
+5. Escalate security, performance, or release risk to the linked supporting skills when needed.
+
+## Handoff Shortlist
+
+- `android-serialization-offline-sync`
+- `android-security-best-practices`

--- a/.agents/skills/android-networking-retrofit-okhttp/references/scenarios.md
+++ b/.agents/skills/android-networking-retrofit-okhttp/references/scenarios.md
@@ -1,0 +1,16 @@
+# Android Networking Retrofit OkHttp Runnable Scenarios
+
+## Happy path
+
+- Goal: Model sync requests and network failures for task refresh.
+- Command: `cd examples/orbittasks-compose && ./gradlew :app:testDebugUnitTest`
+
+## Edge case
+
+- Goal: Handle stale cache and retry behavior in the XML fixture.
+- Command: `cd examples/orbittasks-xml && ./gradlew :app:testDebugUnitTest`
+
+## Failure recovery
+
+- Goal: Differentiate networking prompts from serialization, security, and offline-sync requests.
+- Command: `python3 scripts/eval_triggers.py --skill android-networking-retrofit-okhttp`

--- a/.agents/skills/android-networking-retrofit-okhttp/scripts/run_examples.sh
+++ b/.agents/skills/android-networking-retrofit-okhttp/scripts/run_examples.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+    set -euo pipefail
+
+    cat <<'EOF'
+    Skill: Android Networking Retrofit OkHttp
+    Canonical path: skills/android-networking-retrofit-okhttp
+    Example commands:
+    Happy path: cd examples/orbittasks-compose && ./gradlew :app:testDebugUnitTest
+Edge case: cd examples/orbittasks-xml && ./gradlew :app:testDebugUnitTest
+Failure recovery: python3 scripts/eval_triggers.py --skill android-networking-retrofit-okhttp
+    EOF

--- a/.agents/skills/android-testing-unit/SKILL.md
+++ b/.agents/skills/android-testing-unit/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: "android-testing-unit"
+description: "Write fast, focused Android unit tests for reducers, use cases, repositories, and lifecycle-safe state holders."
+metadata:
+  version: "0.1.0"
+  category: "quality-release"
+  tags: ["android", "testing", "unit-tests", "verification"]
+  triggers:
+    include: ["android unit test strategy", "test viewmodel reducer android", "repository unit tests android", "mock coroutine dependency android", "fast test coverage android"]
+    exclude: ["ui screenshot only", "play store listing", "apk alignment"]
+  owners: ["@android-agent-skills/maintainers"]
+  test_targets: ["examples/orbittasks-compose", "examples/orbittasks-xml", "benchmarks/triggers.jsonl"]
+---
+
+# Android Testing Unit
+
+## When To Use
+
+- Use this skill when the request is about: android unit test strategy, test viewmodel reducer
+  android, repository unit tests android.
+- Primary outcome: Write fast, focused Android unit tests for reducers, use cases, repositories, and
+  lifecycle-safe state holders.
+- Handoff skills when the scope expands:
+- `android-testing-ui`
+- `android-ui-states-validation`
+
+## Workflow
+
+1. Scope the risk surface: correctness, security, performance, test depth, or release automation.
+2. Pick the narrowest verification strategy that still catches the likely regressions.
+3. Instrument the workflow so failures are actionable rather than just red.
+4. Run the relevant checks on the showcase apps and packaging outputs.
+5. Capture any residual risk with explicit follow-up work and owner skills.
+
+## Guardrails
+
+- Prefer reproducible checks in CI over one-off local heroics.
+- Fail with a precise remediation path instead of a vague quality gate.
+- Keep secrets, signing material, and production credentials out of examples and fixtures.
+- Treat performance and security work as engineering tasks with evidence, not folklore.
+
+## Anti-Patterns
+
+- Adding more tests without increasing signal.
+- Shipping benchmarks or security scans that no one can reproduce.
+- Hard-coding release credentials into build logic.
+- Using synthetic metrics with no user-impact interpretation.
+
+## Examples
+
+### Happy path
+
+- Scenario: Cover reducer and formatter logic in both fixture apps with focused local tests.
+- Command:
+  `cd examples/orbittasks-compose && ./gradlew :app:testDebugUnitTest && cd ../orbittasks-xml && ./gradlew :app:testDebugUnitTest`
+
+### Edge case
+
+- Scenario: Mock sync failures and permission-denied branches without instrumentation.
+- Command: `cd examples/orbittasks-compose && ./gradlew :app:testDebugUnitTest`
+
+### Failure recovery
+
+- Scenario: Separate unit-testing requests from UI testing or general architecture cleanup.
+- Command: `python3 scripts/eval_triggers.py --skill android-testing-unit`
+
+## Done Checklist
+
+- The implementation path is explicit, minimal, and tied to the right Android surface.
+- Relevant example commands and benchmark prompts have been exercised or updated.
+- Handoffs to adjacent skills are documented when the request crosses boundaries.
+- Official references cover the chosen pattern and the main migration or troubleshooting path.
+
+## Official References
+
+- [https://developer.android.com/training/testing/local-tests](https://developer.android.com/training/testing/local-tests)
+- [https://developer.android.com/training/testing/fundamentals](https://developer.android.com/training/testing/fundamentals)
+- [https://developer.android.com/topic/libraries/architecture/viewmodel](https://developer.android.com/topic/libraries/architecture/viewmodel)
+- [https://kotlinlang.org/docs/jvm-test-using-junit.html](https://kotlinlang.org/docs/jvm-test-using-junit.html)

--- a/.agents/skills/android-testing-unit/agents/openai.yaml
+++ b/.agents/skills/android-testing-unit/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Android Testing Unit"
+  short_description: "Write fast, focused Android unit tests for reducers, use cases, repositories, and lifecycle-safe state holders"
+  default_prompt: "Use $android-testing-unit when the request is about write fast, focused Android unit tests for reducers, use cases, repositories, and lifecycle-safe state holders."

--- a/.agents/skills/android-testing-unit/references/official-links.md
+++ b/.agents/skills/android-testing-unit/references/official-links.md
@@ -1,0 +1,6 @@
+# Android Testing Unit Official Links
+
+- [https://developer.android.com/training/testing/local-tests](https://developer.android.com/training/testing/local-tests)
+- [https://developer.android.com/training/testing/fundamentals](https://developer.android.com/training/testing/fundamentals)
+- [https://developer.android.com/topic/libraries/architecture/viewmodel](https://developer.android.com/topic/libraries/architecture/viewmodel)
+- [https://kotlinlang.org/docs/jvm-test-using-junit.html](https://kotlinlang.org/docs/jvm-test-using-junit.html)

--- a/.agents/skills/android-testing-unit/references/patterns.md
+++ b/.agents/skills/android-testing-unit/references/patterns.md
@@ -1,0 +1,22 @@
+# Android Testing Unit Patterns
+
+## Selection Notes
+
+- Category: `quality-release`
+- Best fit when the request matches the trigger language in `SKILL.md` and the implementation focus
+  is
+  `Write fast, focused Android unit tests for reducers, use cases, repositories, and lifecycle-safe state holders.`
+- Reach for neighboring skills only after this skill has framed the main problem.
+
+## Default Review Sequence
+
+1. Scope the risk surface: correctness, security, performance, test depth, or release automation.
+2. Pick the narrowest verification strategy that still catches the likely regressions.
+3. Instrument the workflow so failures are actionable rather than just red.
+4. Run the relevant checks on the showcase apps and packaging outputs.
+5. Capture any residual risk with explicit follow-up work and owner skills.
+
+## Handoff Shortlist
+
+- `android-testing-ui`
+- `android-ui-states-validation`

--- a/.agents/skills/android-testing-unit/references/scenarios.md
+++ b/.agents/skills/android-testing-unit/references/scenarios.md
@@ -1,0 +1,17 @@
+# Android Testing Unit Runnable Scenarios
+
+## Happy path
+
+- Goal: Cover reducer and formatter logic in both fixture apps with focused local tests.
+- Command:
+  `cd examples/orbittasks-compose && ./gradlew :app:testDebugUnitTest && cd ../orbittasks-xml && ./gradlew :app:testDebugUnitTest`
+
+## Edge case
+
+- Goal: Mock sync failures and permission-denied branches without instrumentation.
+- Command: `cd examples/orbittasks-compose && ./gradlew :app:testDebugUnitTest`
+
+## Failure recovery
+
+- Goal: Separate unit-testing requests from UI testing or general architecture cleanup.
+- Command: `python3 scripts/eval_triggers.py --skill android-testing-unit`

--- a/.agents/skills/android-testing-unit/scripts/run_examples.sh
+++ b/.agents/skills/android-testing-unit/scripts/run_examples.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+    set -euo pipefail
+
+    cat <<'EOF'
+    Skill: Android Testing Unit
+    Canonical path: skills/android-testing-unit
+    Example commands:
+    Happy path: cd examples/orbittasks-compose && ./gradlew :app:testDebugUnitTest && cd ../orbittasks-xml && ./gradlew :app:testDebugUnitTest
+Edge case: cd examples/orbittasks-compose && ./gradlew :app:testDebugUnitTest
+Failure recovery: python3 scripts/eval_triggers.py --skill android-testing-unit
+    EOF

--- a/.claude/skills/android-architecture-clean/SKILL.md
+++ b/.claude/skills/android-architecture-clean/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: "android-architecture-clean"
+description: "Apply clean architecture boundaries, use cases, repositories, and lifecycle-aware presentation models in Android projects."
+metadata:
+  version: "0.1.0"
+  category: "foundations"
+  tags: ["android", "architecture", "clean-architecture", "layers"]
+  triggers:
+    include: ["clean architecture in android", "split use cases and repositories", "untangle presentation and data layer", "android architecture cleanup", "mvvm to cleaner boundaries"]
+    exclude: ["retrofit config only", "compose animation tweak", "play store release only"]
+  owners: ["@android-agent-skills/maintainers"]
+  test_targets: ["examples/orbittasks-compose", "examples/orbittasks-xml", "benchmarks/triggers.jsonl"]
+---
+
+# Android Architecture Clean
+
+## When To Use
+
+- Use this skill when the request is about: clean architecture in android, split use cases and
+  repositories, untangle presentation and data layer.
+- Primary outcome: Apply clean architecture boundaries, use cases, repositories, and lifecycle-aware
+  presentation models in Android projects.
+- Handoff skills when the scope expands:
+- `android-modularization`
+- `android-state-management`
+
+## Workflow
+
+1. Map the request to the current Android stack, module boundaries, and minimum supported API level.
+2. Inspect the existing implementation for implicit assumptions, duplicate helpers, and outdated
+   patterns.
+3. Apply the smallest change that improves correctness, readability, and long-term maintainability.
+4. Validate the result against the relevant showcase app path and repo benchmarks.
+5. Hand off adjacent work to the next specialized skill only after the core foundation is stable.
+
+## Guardrails
+
+- Prefer official Android and Kotlin guidance over custom local conventions when they conflict.
+- Keep public APIs boring and explicit; avoid clever abstractions that hide Android lifecycle costs.
+- Do not mix architectural cleanup with product behavior changes unless the request explicitly needs
+  both.
+- Document any compatibility constraints that will affect old modules or generated code.
+
+## Anti-Patterns
+
+- Sprinkling helpers across modules without a clear ownership boundary.
+- Introducing framework-specific code into pure domain or data layers.
+- Refactoring every adjacent file when only one contract needed to change.
+- Leaving migration notes implied instead of writing them down.
+
+## Examples
+
+### Happy path
+
+- Scenario: Separate OrbitTasks feature state, use case, and repository contracts.
+- Command: `cd examples/orbittasks-compose && ./gradlew :app:testDebugUnitTest`
+
+### Edge case
+
+- Scenario: Keep XML activity actions thin while preserving saved-state behavior.
+- Command: `cd examples/orbittasks-xml && ./gradlew :app:testDebugUnitTest`
+
+### Failure recovery
+
+- Scenario: Catch trigger confusion against modularization and state-management requests.
+- Command: `python3 scripts/eval_triggers.py --skill android-architecture-clean`
+
+## Done Checklist
+
+- The implementation path is explicit, minimal, and tied to the right Android surface.
+- Relevant example commands and benchmark prompts have been exercised or updated.
+- Handoffs to adjacent skills are documented when the request crosses boundaries.
+- Official references cover the chosen pattern and the main migration or troubleshooting path.
+
+## Official References
+
+- [https://developer.android.com/topic/architecture](https://developer.android.com/topic/architecture)
+- [https://developer.android.com/topic/architecture/recommendations](https://developer.android.com/topic/architecture/recommendations)
+- [https://developer.android.com/jetpack/guide](https://developer.android.com/jetpack/guide)
+- [https://developer.android.com/topic/libraries/architecture/viewmodel](https://developer.android.com/topic/libraries/architecture/viewmodel)

--- a/.claude/skills/android-architecture-clean/agents/openai.yaml
+++ b/.claude/skills/android-architecture-clean/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Android Architecture Clean"
+  short_description: "Apply clean architecture boundaries, use cases, repositories, and lifecycle-aware presentation models in Android projects"
+  default_prompt: "Use $android-architecture-clean when the request is about apply clean architecture boundaries, use cases, repositories, and lifecycle-aware presentation models in Android projects."

--- a/.claude/skills/android-architecture-clean/references/official-links.md
+++ b/.claude/skills/android-architecture-clean/references/official-links.md
@@ -1,0 +1,6 @@
+# Android Architecture Clean Official Links
+
+- [https://developer.android.com/topic/architecture](https://developer.android.com/topic/architecture)
+- [https://developer.android.com/topic/architecture/recommendations](https://developer.android.com/topic/architecture/recommendations)
+- [https://developer.android.com/jetpack/guide](https://developer.android.com/jetpack/guide)
+- [https://developer.android.com/topic/libraries/architecture/viewmodel](https://developer.android.com/topic/libraries/architecture/viewmodel)

--- a/.claude/skills/android-architecture-clean/references/patterns.md
+++ b/.claude/skills/android-architecture-clean/references/patterns.md
@@ -1,0 +1,23 @@
+# Android Architecture Clean Patterns
+
+## Selection Notes
+
+- Category: `foundations`
+- Best fit when the request matches the trigger language in `SKILL.md` and the implementation focus
+  is
+  `Apply clean architecture boundaries, use cases, repositories, and lifecycle-aware presentation models in Android projects.`
+- Reach for neighboring skills only after this skill has framed the main problem.
+
+## Default Review Sequence
+
+1. Map the request to the current Android stack, module boundaries, and minimum supported API level.
+2. Inspect the existing implementation for implicit assumptions, duplicate helpers, and outdated
+   patterns.
+3. Apply the smallest change that improves correctness, readability, and long-term maintainability.
+4. Validate the result against the relevant showcase app path and repo benchmarks.
+5. Hand off adjacent work to the next specialized skill only after the core foundation is stable.
+
+## Handoff Shortlist
+
+- `android-modularization`
+- `android-state-management`

--- a/.claude/skills/android-architecture-clean/references/scenarios.md
+++ b/.claude/skills/android-architecture-clean/references/scenarios.md
@@ -1,0 +1,16 @@
+# Android Architecture Clean Runnable Scenarios
+
+## Happy path
+
+- Goal: Separate OrbitTasks feature state, use case, and repository contracts.
+- Command: `cd examples/orbittasks-compose && ./gradlew :app:testDebugUnitTest`
+
+## Edge case
+
+- Goal: Keep XML activity actions thin while preserving saved-state behavior.
+- Command: `cd examples/orbittasks-xml && ./gradlew :app:testDebugUnitTest`
+
+## Failure recovery
+
+- Goal: Catch trigger confusion against modularization and state-management requests.
+- Command: `python3 scripts/eval_triggers.py --skill android-architecture-clean`

--- a/.claude/skills/android-architecture-clean/scripts/run_examples.sh
+++ b/.claude/skills/android-architecture-clean/scripts/run_examples.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+    set -euo pipefail
+
+    cat <<'EOF'
+    Skill: Android Architecture Clean
+    Canonical path: skills/android-architecture-clean
+    Example commands:
+    Happy path: cd examples/orbittasks-compose && ./gradlew :app:testDebugUnitTest
+Edge case: cd examples/orbittasks-xml && ./gradlew :app:testDebugUnitTest
+Failure recovery: python3 scripts/eval_triggers.py --skill android-architecture-clean
+    EOF

--- a/.claude/skills/android-compose-foundations/SKILL.md
+++ b/.claude/skills/android-compose-foundations/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: "android-compose-foundations"
+description: "Build Android UI with Jetpack Compose foundations, layouts, modifiers, theming, and stable component structure."
+metadata:
+  version: "0.1.0"
+  category: "ui"
+  tags: ["android", "compose", "ui", "foundation"]
+  triggers:
+    include: ["jetpack compose screen", "compose layout in android", "modifier cleanup compose", "android compose component structure", "compose foundation best practices"]
+    exclude: ["xml fragment problem", "retrofit interceptor", "play release pipeline"]
+  owners: ["@android-agent-skills/maintainers"]
+  test_targets: ["examples/orbittasks-compose", "examples/orbittasks-xml", "benchmarks/triggers.jsonl"]
+---
+
+# Android Compose Foundations
+
+## When To Use
+
+- Use this skill when the request is about: jetpack compose screen, compose layout in android,
+  modifier cleanup compose.
+- Primary outcome: Build Android UI with Jetpack Compose foundations, layouts, modifiers, theming,
+  and stable component structure.
+- Handoff skills when the scope expands:
+- `android-compose-state-effects`
+- `android-material3-design-system`
+
+## Workflow
+
+1. Identify whether the target surface is Compose, View system, or a mixed interoperability screen.
+2. Select the lowest-friction UI pattern that satisfies responsiveness, accessibility, and
+   performance needs.
+3. Build the UI around stable state, explicit side effects, and reusable design tokens.
+4. Exercise edge cases such as long text, font scaling, RTL, and narrow devices in the fixture apps.
+5. Validate with unit, UI, and screenshot-friendly checks before handing off.
+
+## Guardrails
+
+- Optimize for stable state and predictable rendering before adding animation or abstraction.
+- Respect accessibility semantics, contrast, focus order, and touch target guidance by default.
+- Do not mix Compose and View system ownership without an explicit interoperability boundary.
+- Prefer measured performance work over premature micro-optimizations.
+
+## Anti-Patterns
+
+- Embedding navigation or business logic directly in leaf UI components.
+- Using fixed dimensions that break on localization or dynamic text.
+- Ignoring semantics and announcing only visual changes.
+- Porting XML patterns directly into Compose without adapting the mental model.
+
+## Examples
+
+### Happy path
+
+- Scenario: Refine the Compose OrbitTasks board with stable slots and theme tokens.
+- Command: `cd examples/orbittasks-compose && ./gradlew :app:testDebugUnitTest`
+
+### Edge case
+
+- Scenario: Keep previews and layout behavior stable under narrow widths and long text.
+- Command: `cd examples/orbittasks-compose && ./gradlew :app:assembleDebug`
+
+### Failure recovery
+
+- Scenario: Keep general Compose requests from drifting into state/effects or performance work.
+- Command: `python3 scripts/eval_triggers.py --skill android-compose-foundations`
+
+## Done Checklist
+
+- The implementation path is explicit, minimal, and tied to the right Android surface.
+- Relevant example commands and benchmark prompts have been exercised or updated.
+- Handoffs to adjacent skills are documented when the request crosses boundaries.
+- Official references cover the chosen pattern and the main migration or troubleshooting path.
+
+## Official References
+
+- [https://developer.android.com/develop/ui/compose](https://developer.android.com/develop/ui/compose)
+- [https://developer.android.com/develop/ui/compose/layouts/basics](https://developer.android.com/develop/ui/compose/layouts/basics)
+- [https://developer.android.com/develop/ui/compose/modifiers](https://developer.android.com/develop/ui/compose/modifiers)
+- [https://developer.android.com/develop/ui/compose/designsystems/material3](https://developer.android.com/develop/ui/compose/designsystems/material3)

--- a/.claude/skills/android-compose-foundations/agents/openai.yaml
+++ b/.claude/skills/android-compose-foundations/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Android Compose Foundations"
+  short_description: "Build Android UI with Jetpack Compose foundations, layouts, modifiers, theming, and stable component structure"
+  default_prompt: "Use $android-compose-foundations when the request is about build Android UI with Jetpack Compose foundations, layouts, modifiers, theming, and stable component structure."

--- a/.claude/skills/android-compose-foundations/references/official-links.md
+++ b/.claude/skills/android-compose-foundations/references/official-links.md
@@ -1,0 +1,6 @@
+# Android Compose Foundations Official Links
+
+- [https://developer.android.com/develop/ui/compose](https://developer.android.com/develop/ui/compose)
+- [https://developer.android.com/develop/ui/compose/layouts/basics](https://developer.android.com/develop/ui/compose/layouts/basics)
+- [https://developer.android.com/develop/ui/compose/modifiers](https://developer.android.com/develop/ui/compose/modifiers)
+- [https://developer.android.com/develop/ui/compose/designsystems/material3](https://developer.android.com/develop/ui/compose/designsystems/material3)

--- a/.claude/skills/android-compose-foundations/references/patterns.md
+++ b/.claude/skills/android-compose-foundations/references/patterns.md
@@ -1,0 +1,23 @@
+# Android Compose Foundations Patterns
+
+## Selection Notes
+
+- Category: `ui`
+- Best fit when the request matches the trigger language in `SKILL.md` and the implementation focus
+  is
+  `Build Android UI with Jetpack Compose foundations, layouts, modifiers, theming, and stable component structure.`
+- Reach for neighboring skills only after this skill has framed the main problem.
+
+## Default Review Sequence
+
+1. Identify whether the target surface is Compose, View system, or a mixed interoperability screen.
+2. Select the lowest-friction UI pattern that satisfies responsiveness, accessibility, and
+   performance needs.
+3. Build the UI around stable state, explicit side effects, and reusable design tokens.
+4. Exercise edge cases such as long text, font scaling, RTL, and narrow devices in the fixture apps.
+5. Validate with unit, UI, and screenshot-friendly checks before handing off.
+
+## Handoff Shortlist
+
+- `android-compose-state-effects`
+- `android-material3-design-system`

--- a/.claude/skills/android-compose-foundations/references/scenarios.md
+++ b/.claude/skills/android-compose-foundations/references/scenarios.md
@@ -1,0 +1,16 @@
+# Android Compose Foundations Runnable Scenarios
+
+## Happy path
+
+- Goal: Refine the Compose OrbitTasks board with stable slots and theme tokens.
+- Command: `cd examples/orbittasks-compose && ./gradlew :app:testDebugUnitTest`
+
+## Edge case
+
+- Goal: Keep previews and layout behavior stable under narrow widths and long text.
+- Command: `cd examples/orbittasks-compose && ./gradlew :app:assembleDebug`
+
+## Failure recovery
+
+- Goal: Keep general Compose requests from drifting into state/effects or performance work.
+- Command: `python3 scripts/eval_triggers.py --skill android-compose-foundations`

--- a/.claude/skills/android-compose-foundations/scripts/run_examples.sh
+++ b/.claude/skills/android-compose-foundations/scripts/run_examples.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+    set -euo pipefail
+
+    cat <<'EOF'
+    Skill: Android Compose Foundations
+    Canonical path: skills/android-compose-foundations
+    Example commands:
+    Happy path: cd examples/orbittasks-compose && ./gradlew :app:testDebugUnitTest
+Edge case: cd examples/orbittasks-compose && ./gradlew :app:assembleDebug
+Failure recovery: python3 scripts/eval_triggers.py --skill android-compose-foundations
+    EOF

--- a/.claude/skills/android-coroutines-flow/SKILL.md
+++ b/.claude/skills/android-coroutines-flow/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: "android-coroutines-flow"
+description: "Use coroutines, Flow, structured concurrency, dispatchers, and cancellation-safe Android async pipelines."
+metadata:
+  version: "0.1.0"
+  category: "foundations"
+  tags: ["android", "coroutines", "flow", "async"]
+  triggers:
+    include: ["android flow collection", "fix coroutine scope in android", "structured concurrency in viewmodel", "flow retry caching android", "dispatcher cleanup in android"]
+    exclude: ["play release notes", "xml layout spacing", "hilt module graph only"]
+  owners: ["@android-agent-skills/maintainers"]
+  test_targets: ["examples/orbittasks-compose", "examples/orbittasks-xml", "benchmarks/triggers.jsonl"]
+---
+
+# Android Coroutines Flow
+
+## When To Use
+
+- Use this skill when the request is about: android flow collection, fix coroutine scope in android,
+  structured concurrency in viewmodel.
+- Primary outcome: Use coroutines, Flow, structured concurrency, dispatchers, and cancellation-safe
+  Android async pipelines.
+- Handoff skills when the scope expands:
+- `android-state-management`
+- `android-workmanager-notifications`
+
+## Workflow
+
+1. Map the request to the current Android stack, module boundaries, and minimum supported API level.
+2. Inspect the existing implementation for implicit assumptions, duplicate helpers, and outdated
+   patterns.
+3. Apply the smallest change that improves correctness, readability, and long-term maintainability.
+4. Validate the result against the relevant showcase app path and repo benchmarks.
+5. Hand off adjacent work to the next specialized skill only after the core foundation is stable.
+
+## Guardrails
+
+- Prefer official Android and Kotlin guidance over custom local conventions when they conflict.
+- Keep public APIs boring and explicit; avoid clever abstractions that hide Android lifecycle costs.
+- Do not mix architectural cleanup with product behavior changes unless the request explicitly needs
+  both.
+- Document any compatibility constraints that will affect old modules or generated code.
+
+## Anti-Patterns
+
+- Sprinkling helpers across modules without a clear ownership boundary.
+- Introducing framework-specific code into pure domain or data layers.
+- Refactoring every adjacent file when only one contract needed to change.
+- Leaving migration notes implied instead of writing them down.
+
+## Remediation Examples
+
+### Inject dispatchers instead of hard-coding them
+
+```kotlin
+class TaskRepository(
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+) {
+    suspend fun refresh(): List<TaskUiModel> = withContext(ioDispatcher) { loadTasks() }
+}
+```
+
+### Collect flows with lifecycle awareness
+
+```kotlin
+viewLifecycleOwner.lifecycleScope.launch {
+    viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+        viewModel.uiState.collect { render(it) }
+    }
+}
+```
+
+### Preserve cancellation in generic error handling
+
+```kotlin
+try {
+    repository.refresh()
+} catch (error: CancellationException) {
+    throw error
+} catch (error: Exception) {
+    emit(UiState.Error(error))
+}
+```
+
+## Examples
+
+### Happy path
+
+- Scenario: Model task updates as StateFlow and shared event channels in the Compose fixture.
+- Command: `cd examples/orbittasks-compose && ./gradlew :app:testDebugUnitTest`
+
+### Edge case
+
+- Scenario: Recover from cancellation and configuration changes in the XML activity flow.
+- Command: `cd examples/orbittasks-xml && ./gradlew :app:testDebugUnitTest`
+
+### Failure recovery
+
+- Scenario: Disambiguate coroutine requests from state-management and WorkManager prompts.
+- Command: `python3 scripts/eval_triggers.py --skill android-coroutines-flow`
+
+## Done Checklist
+
+- The implementation path is explicit, minimal, and tied to the right Android surface.
+- Relevant example commands and benchmark prompts have been exercised or updated.
+- Handoffs to adjacent skills are documented when the request crosses boundaries.
+- Official references cover the chosen pattern and the main migration or troubleshooting path.
+
+## Official References
+
+- [https://developer.android.com/kotlin/coroutines](https://developer.android.com/kotlin/coroutines)
+- [https://developer.android.com/topic/libraries/architecture/coroutines](https://developer.android.com/topic/libraries/architecture/coroutines)
+- [https://kotlinlang.org/docs/coroutines-overview.html](https://kotlinlang.org/docs/coroutines-overview.html)
+- [https://kotlinlang.org/docs/flow.html](https://kotlinlang.org/docs/flow.html)

--- a/.claude/skills/android-coroutines-flow/agents/openai.yaml
+++ b/.claude/skills/android-coroutines-flow/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Android Coroutines Flow"
+  short_description: "Use coroutines, Flow, structured concurrency, dispatchers, and cancellation-safe Android async pipelines"
+  default_prompt: "Use $android-coroutines-flow when the request is about use coroutines, Flow, structured concurrency, dispatchers, and cancellation-safe Android async pipelines."

--- a/.claude/skills/android-coroutines-flow/references/official-links.md
+++ b/.claude/skills/android-coroutines-flow/references/official-links.md
@@ -1,0 +1,6 @@
+# Android Coroutines Flow Official Links
+
+- [https://developer.android.com/kotlin/coroutines](https://developer.android.com/kotlin/coroutines)
+- [https://developer.android.com/topic/libraries/architecture/coroutines](https://developer.android.com/topic/libraries/architecture/coroutines)
+- [https://kotlinlang.org/docs/coroutines-overview.html](https://kotlinlang.org/docs/coroutines-overview.html)
+- [https://kotlinlang.org/docs/flow.html](https://kotlinlang.org/docs/flow.html)

--- a/.claude/skills/android-coroutines-flow/references/patterns.md
+++ b/.claude/skills/android-coroutines-flow/references/patterns.md
@@ -1,0 +1,23 @@
+# Android Coroutines Flow Patterns
+
+## Selection Notes
+
+- Category: `foundations`
+- Best fit when the request matches the trigger language in `SKILL.md` and the implementation focus
+  is
+  `Use coroutines, Flow, structured concurrency, dispatchers, and cancellation-safe Android async pipelines.`
+- Reach for neighboring skills only after this skill has framed the main problem.
+
+## Default Review Sequence
+
+1. Map the request to the current Android stack, module boundaries, and minimum supported API level.
+2. Inspect the existing implementation for implicit assumptions, duplicate helpers, and outdated
+   patterns.
+3. Apply the smallest change that improves correctness, readability, and long-term maintainability.
+4. Validate the result against the relevant showcase app path and repo benchmarks.
+5. Hand off adjacent work to the next specialized skill only after the core foundation is stable.
+
+## Handoff Shortlist
+
+- `android-state-management`
+- `android-workmanager-notifications`

--- a/.claude/skills/android-coroutines-flow/references/scenarios.md
+++ b/.claude/skills/android-coroutines-flow/references/scenarios.md
@@ -1,0 +1,16 @@
+# Android Coroutines Flow Runnable Scenarios
+
+## Happy path
+
+- Goal: Model task updates as StateFlow and shared event channels in the Compose fixture.
+- Command: `cd examples/orbittasks-compose && ./gradlew :app:testDebugUnitTest`
+
+## Edge case
+
+- Goal: Recover from cancellation and configuration changes in the XML activity flow.
+- Command: `cd examples/orbittasks-xml && ./gradlew :app:testDebugUnitTest`
+
+## Failure recovery
+
+- Goal: Disambiguate coroutine requests from state-management and WorkManager prompts.
+- Command: `python3 scripts/eval_triggers.py --skill android-coroutines-flow`

--- a/.claude/skills/android-coroutines-flow/scripts/run_examples.sh
+++ b/.claude/skills/android-coroutines-flow/scripts/run_examples.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+    set -euo pipefail
+
+    cat <<'EOF'
+    Skill: Android Coroutines Flow
+    Canonical path: skills/android-coroutines-flow
+    Example commands:
+    Happy path: cd examples/orbittasks-compose && ./gradlew :app:testDebugUnitTest
+Edge case: cd examples/orbittasks-xml && ./gradlew :app:testDebugUnitTest
+Failure recovery: python3 scripts/eval_triggers.py --skill android-coroutines-flow
+    EOF

--- a/.claude/skills/android-di-hilt/SKILL.md
+++ b/.claude/skills/android-di-hilt/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: "android-di-hilt"
+description: "Wire Android dependency injection with Hilt, scopes, testing overrides, and module ownership boundaries."
+metadata:
+  version: "0.1.0"
+  category: "foundations"
+  tags: ["android", "hilt", "dependency-injection", "testing"]
+  triggers:
+    include: ["android hilt setup", "inject viewmodel repository hilt", "scope dependency in android", "replace manual service locator", "hilt testing override", "android-di-hilt skill", "scope dependency in android hilt", "hilt component scope mismatch", "hilt entry point android"]
+    exclude: ["retrofit serialization only", "compose typography only", "gradle wrapper upgrade", "collect flow in compose screen", "state matrix before release"]
+  owners: ["@android-agent-skills/maintainers"]
+  test_targets: ["examples/orbittasks-compose", "examples/orbittasks-xml", "benchmarks/triggers.jsonl"]
+---
+
+# Android DI Hilt
+
+## When To Use
+
+- Use this skill when the request is about: android hilt setup, inject viewmodel repository hilt,
+  scope dependency in android.
+- Primary outcome: Wire Android dependency injection with Hilt, scopes, testing overrides, and
+  module ownership boundaries.
+- Reach for this skill when the hard part is component ownership, bindings, scopes, entry points, or
+  test replacement. If the request is only about networking APIs or reducer design, use the
+  neighboring skill instead.
+- Handoff skills when the scope expands:
+- `android-testing-unit`
+- `android-networking-retrofit-okhttp`
+
+## Workflow
+
+1. Identify the injection boundary first: app-wide singleton, activity-retained, ViewModel, worker,
+   service, or entry point from unsupported framework code.
+2. Decide what should be bound: constructor injection, `@Binds`, `@Provides`, qualifiers,
+   multibindings, or assisted injection.
+3. Match lifetime to scope explicitly so dependencies do not outlive their owner or rebuild too
+   often.
+4. Verify replacement strategy for tests with Hilt test modules, uninstall modules, or fakes at the
+   right component boundary.
+5. Hand off API-specific or architectural questions only after the DI graph ownership is correct.
+
+## Guardrails
+
+- Prefer constructor injection for app code you own.
+- Use qualifiers and scope annotations deliberately; ambiguous bindings are a graph smell, not a
+  convenience.
+- Keep Hilt modules close to the ownership boundary they configure.
+- Treat test replacement as part of the design, not an afterthought.
+
+## Anti-Patterns
+
+- Making everything `@Singleton` to silence scope questions.
+- Hiding business construction logic inside giant `@Provides` methods when constructor injection
+  would suffice.
+- Using Hilt modules as a dumping ground for unrelated bindings across modules.
+- Confusing DI graph ownership with app architecture ownership.
+
+## Review Focus
+
+- Component and scope alignment.
+- Binding style and qualifier clarity.
+- Unsupported-entry-point bridges and test replacement strategy.
+- Module ownership boundaries across features and core code.
+
+## Examples
+
+### Happy path
+
+- Scenario: Inject OrbitTasks repositories and dispatchers with clear Hilt scopes.
+- Command: `cd examples/orbittasks-compose && ./gradlew :app:testDebugUnitTest`
+
+### Edge case
+
+- Scenario: Swap fake dependencies in the XML fixture for deterministic tests.
+- Command: `cd examples/orbittasks-xml && ./gradlew :app:testDebugUnitTest`
+
+### Failure recovery
+
+- Scenario: Catch DI-specific prompts before they drift into architecture-clean or networking.
+- Command: `python3 scripts/eval_triggers.py --skill android-di-hilt`
+
+## Done Checklist
+
+- Component lifetime matches dependency lifetime.
+- Binding style is explicit and testable.
+- Test overrides or fakes are planned at the right graph boundary.
+- Non-DI work is handed off instead of buried in modules.
+
+## Official References
+
+- [https://developer.android.com/training/dependency-injection/hilt-android](https://developer.android.com/training/dependency-injection/hilt-android)
+- [https://developer.android.com/training/dependency-injection/hilt-testing](https://developer.android.com/training/dependency-injection/hilt-testing)
+- [https://developer.android.com/training/dependency-injection/hilt-multi-module](https://developer.android.com/training/dependency-injection/hilt-multi-module)
+- [https://developer.android.com/topic/libraries/architecture/viewmodel](https://developer.android.com/topic/libraries/architecture/viewmodel)
+- [https://developer.android.com/training/dependency-injection/manual](https://developer.android.com/training/dependency-injection/manual)

--- a/.claude/skills/android-di-hilt/agents/openai.yaml
+++ b/.claude/skills/android-di-hilt/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Android DI Hilt"
+  short_description: "Wire Android dependency injection with Hilt, scopes, testing overrides, and module ownership boundaries"
+  default_prompt: "Use $android-di-hilt when the request is about wire Android dependency injection with Hilt, scopes, testing overrides, and module ownership boundaries."

--- a/.claude/skills/android-di-hilt/references/official-links.md
+++ b/.claude/skills/android-di-hilt/references/official-links.md
@@ -1,0 +1,7 @@
+# Android DI Hilt Official Links
+
+- [https://developer.android.com/training/dependency-injection/hilt-android](https://developer.android.com/training/dependency-injection/hilt-android)
+- [https://developer.android.com/training/dependency-injection/hilt-testing](https://developer.android.com/training/dependency-injection/hilt-testing)
+- [https://developer.android.com/training/dependency-injection/hilt-multi-module](https://developer.android.com/training/dependency-injection/hilt-multi-module)
+- [https://developer.android.com/topic/libraries/architecture/viewmodel](https://developer.android.com/topic/libraries/architecture/viewmodel)
+- [https://developer.android.com/training/dependency-injection/manual](https://developer.android.com/training/dependency-injection/manual)

--- a/.claude/skills/android-di-hilt/references/patterns.md
+++ b/.claude/skills/android-di-hilt/references/patterns.md
@@ -1,0 +1,40 @@
+# Android DI Hilt Patterns
+
+## Selection Notes
+
+- Category: `foundations`
+- Best fit when the request matches the trigger language in `SKILL.md` and the implementation focus
+  is
+  `Wire Android dependency injection with Hilt, scopes, testing overrides, and module ownership boundaries.`
+- Reach for neighboring skills only after this skill has framed the main problem.
+
+## Review Sequence
+
+- Ownership:
+  which component owns the dependency and why
+- Binding style:
+  constructor injection vs `@Binds` vs `@Provides` vs entry point
+- Lifetime:
+  singleton vs retained vs ViewModel vs shorter-lived scopes
+- Testing:
+  fake/replacement strategy and graph override location
+
+## Default Review Sequence
+
+1. Identify the injection boundary and owner component.
+2. Choose the simplest binding style that fits.
+3. Match scope to lifetime deliberately.
+4. Plan test replacement at the same graph boundary.
+5. Hand off non-DI concerns once the graph is coherent.
+
+## Best-Practice Notes
+
+- Constructor injection is the default when you control the type.
+- Qualifiers are often clearer than multiple similar providers with implicit selection.
+- Multi-module Hilt setups need explicit ownership to avoid “god modules.”
+- Scope bugs are usually ownership bugs first.
+
+## Handoff Shortlist
+
+- `android-testing-unit`
+- `android-networking-retrofit-okhttp`

--- a/.claude/skills/android-di-hilt/references/scenarios.md
+++ b/.claude/skills/android-di-hilt/references/scenarios.md
@@ -1,0 +1,18 @@
+# Android DI Hilt Runnable Scenarios
+
+## Happy path
+
+- Goal: Inject OrbitTasks repositories and dispatchers with clear Hilt scopes and explicit
+  qualifiers.
+- Command: `cd examples/orbittasks-compose && ./gradlew :app:testDebugUnitTest`
+
+## Edge case
+
+- Goal: Swap fake dependencies in the XML fixture with graph overrides at the correct component
+  boundary.
+- Command: `cd examples/orbittasks-xml && ./gradlew :app:testDebugUnitTest`
+
+## Failure recovery
+
+- Goal: Catch DI-specific prompts before they drift into architecture-clean or networking.
+- Command: `python3 scripts/eval_triggers.py --skill android-di-hilt`

--- a/.claude/skills/android-di-hilt/scripts/run_examples.sh
+++ b/.claude/skills/android-di-hilt/scripts/run_examples.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+    set -euo pipefail
+
+    cat <<'EOF'
+    Skill: Android DI Hilt
+    Canonical path: skills/android-di-hilt
+    Example commands:
+    Happy path: cd examples/orbittasks-compose && ./gradlew :app:testDebugUnitTest
+Edge case: cd examples/orbittasks-xml && ./gradlew :app:testDebugUnitTest
+Failure recovery: python3 scripts/eval_triggers.py --skill android-di-hilt
+    EOF

--- a/.claude/skills/android-gradle-build-logic/SKILL.md
+++ b/.claude/skills/android-gradle-build-logic/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: "android-gradle-build-logic"
+description: "Shape Android build logic with Gradle, version catalogs, plugins, convention patterns, and toolchain compatibility."
+metadata:
+  version: "0.1.0"
+  category: "foundations"
+  tags: ["android", "gradle", "build", "toolchain"]
+  triggers:
+    include: ["android gradle plugin setup", "fix build logic for android modules", "version catalog for android repo", "gradle convention cleanup for android", "agp build logic change"]
+    exclude: ["room schema migration only", "compose layout only", "notification permission flow"]
+  owners: ["@android-agent-skills/maintainers"]
+  test_targets: ["examples/orbittasks-compose", "examples/orbittasks-xml", "benchmarks/triggers.jsonl"]
+---
+
+# Android Gradle Build Logic
+
+## When To Use
+
+- Use this skill when the request is about: android gradle plugin setup, fix build logic for android
+  modules, version catalog for android repo.
+- Primary outcome: Shape Android build logic with Gradle, version catalogs, plugins, convention
+  patterns, and toolchain compatibility.
+- Handoff skills when the scope expands:
+- `android-modernization-upgrade`
+- `android-ci-cd-release-playstore`
+
+## Workflow
+
+1. Map the request to the current Android stack, module boundaries, and minimum supported API level.
+2. Inspect the existing implementation for implicit assumptions, duplicate helpers, and outdated
+   patterns.
+3. Apply the smallest change that improves correctness, readability, and long-term maintainability.
+4. Validate the result against the relevant showcase app path and repo benchmarks.
+5. Hand off adjacent work to the next specialized skill only after the core foundation is stable.
+
+## Guardrails
+
+- Prefer official Android and Kotlin guidance over custom local conventions when they conflict.
+- Keep public APIs boring and explicit; avoid clever abstractions that hide Android lifecycle costs.
+- Do not mix architectural cleanup with product behavior changes unless the request explicitly needs
+  both.
+- Document any compatibility constraints that will affect old modules or generated code.
+
+## Anti-Patterns
+
+- Sprinkling helpers across modules without a clear ownership boundary.
+- Introducing framework-specific code into pure domain or data layers.
+- Refactoring every adjacent file when only one contract needed to change.
+- Leaving migration notes implied instead of writing them down.
+
+## Examples
+
+### Happy path
+
+- Scenario: Run the Compose showcase build from a clean checkout with version catalogs.
+- Command: `cd examples/orbittasks-compose && ./gradlew :app:assembleDebug`
+
+### Edge case
+
+- Scenario: Validate shared repositories and plugin management in the XML fixture.
+- Command: `cd examples/orbittasks-xml && ./gradlew :app:assembleDebug`
+
+### Failure recovery
+
+- Scenario: Benchmark build-logic trigger precision against modernization and CI skills.
+- Command: `python3 scripts/eval_triggers.py --skill android-gradle-build-logic`
+
+## Done Checklist
+
+- The implementation path is explicit, minimal, and tied to the right Android surface.
+- Relevant example commands and benchmark prompts have been exercised or updated.
+- Handoffs to adjacent skills are documented when the request crosses boundaries.
+- Official references cover the chosen pattern and the main migration or troubleshooting path.
+
+## Official References
+
+- [https://developer.android.com/build](https://developer.android.com/build)
+- [https://developer.android.com/build/releases/gradle-plugin](https://developer.android.com/build/releases/gradle-plugin)
+- [https://developer.android.com/build/migrate-to-built-in-kotlin](https://developer.android.com/build/migrate-to-built-in-kotlin)
+- [https://docs.gradle.org/current/userguide/userguide.html](https://docs.gradle.org/current/userguide/userguide.html)

--- a/.claude/skills/android-gradle-build-logic/agents/openai.yaml
+++ b/.claude/skills/android-gradle-build-logic/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Android Gradle Build Logic"
+  short_description: "Shape Android build logic with Gradle, version catalogs, plugins, convention patterns, and toolchain compatibility"
+  default_prompt: "Use $android-gradle-build-logic when the request is about shape Android build logic with Gradle, version catalogs, plugins, convention patterns, and toolchain compatibility."

--- a/.claude/skills/android-gradle-build-logic/references/official-links.md
+++ b/.claude/skills/android-gradle-build-logic/references/official-links.md
@@ -1,0 +1,6 @@
+# Android Gradle Build Logic Official Links
+
+- [https://developer.android.com/build](https://developer.android.com/build)
+- [https://developer.android.com/build/releases/gradle-plugin](https://developer.android.com/build/releases/gradle-plugin)
+- [https://developer.android.com/build/migrate-to-built-in-kotlin](https://developer.android.com/build/migrate-to-built-in-kotlin)
+- [https://docs.gradle.org/current/userguide/userguide.html](https://docs.gradle.org/current/userguide/userguide.html)

--- a/.claude/skills/android-gradle-build-logic/references/patterns.md
+++ b/.claude/skills/android-gradle-build-logic/references/patterns.md
@@ -1,0 +1,23 @@
+# Android Gradle Build Logic Patterns
+
+## Selection Notes
+
+- Category: `foundations`
+- Best fit when the request matches the trigger language in `SKILL.md` and the implementation focus
+  is
+  `Shape Android build logic with Gradle, version catalogs, plugins, convention patterns, and toolchain compatibility.`
+- Reach for neighboring skills only after this skill has framed the main problem.
+
+## Default Review Sequence
+
+1. Map the request to the current Android stack, module boundaries, and minimum supported API level.
+2. Inspect the existing implementation for implicit assumptions, duplicate helpers, and outdated
+   patterns.
+3. Apply the smallest change that improves correctness, readability, and long-term maintainability.
+4. Validate the result against the relevant showcase app path and repo benchmarks.
+5. Hand off adjacent work to the next specialized skill only after the core foundation is stable.
+
+## Handoff Shortlist
+
+- `android-modernization-upgrade`
+- `android-ci-cd-release-playstore`

--- a/.claude/skills/android-gradle-build-logic/references/scenarios.md
+++ b/.claude/skills/android-gradle-build-logic/references/scenarios.md
@@ -1,0 +1,16 @@
+# Android Gradle Build Logic Runnable Scenarios
+
+## Happy path
+
+- Goal: Run the Compose showcase build from a clean checkout with version catalogs.
+- Command: `cd examples/orbittasks-compose && ./gradlew :app:assembleDebug`
+
+## Edge case
+
+- Goal: Validate shared repositories and plugin management in the XML fixture.
+- Command: `cd examples/orbittasks-xml && ./gradlew :app:assembleDebug`
+
+## Failure recovery
+
+- Goal: Benchmark build-logic trigger precision against modernization and CI skills.
+- Command: `python3 scripts/eval_triggers.py --skill android-gradle-build-logic`

--- a/.claude/skills/android-gradle-build-logic/scripts/run_examples.sh
+++ b/.claude/skills/android-gradle-build-logic/scripts/run_examples.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+    set -euo pipefail
+
+    cat <<'EOF'
+    Skill: Android Gradle Build Logic
+    Canonical path: skills/android-gradle-build-logic
+    Example commands:
+    Happy path: cd examples/orbittasks-compose && ./gradlew :app:assembleDebug
+Edge case: cd examples/orbittasks-xml && ./gradlew :app:assembleDebug
+Failure recovery: python3 scripts/eval_triggers.py --skill android-gradle-build-logic
+    EOF

--- a/.claude/skills/android-kotlin-core/SKILL.md
+++ b/.claude/skills/android-kotlin-core/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: "android-kotlin-core"
+description: "Use Kotlin idioms safely in Android apps, including nullability, data classes, sealed types, extension functions, and collection pipelines."
+metadata:
+  version: "0.1.0"
+  category: "foundations"
+  tags: ["android", "kotlin", "foundation", "api-design"]
+  triggers:
+    include: ["kotlin cleanup in android app", "convert verbose android java-style kotlin", "sealed classes for ui state", "extension functions for android feature", "improve kotlin readability in android module"]
+    exclude: ["full gradle upgrade", "compose navigation only", "release play console setup"]
+  owners: ["@android-agent-skills/maintainers"]
+  test_targets: ["examples/orbittasks-compose", "examples/orbittasks-xml", "benchmarks/triggers.jsonl"]
+---
+
+# Android Kotlin Core
+
+## When To Use
+
+- Use this skill when the request is about: kotlin cleanup in android app, convert verbose android
+  java-style kotlin, sealed classes for ui state.
+- Primary outcome: Use Kotlin idioms safely in Android apps, including nullability, data classes,
+  sealed types, extension functions, and collection pipelines.
+- Handoff skills when the scope expands:
+- `android-state-management`
+- `android-testing-unit`
+
+## Workflow
+
+1. Map the request to the current Android stack, module boundaries, and minimum supported API level.
+2. Inspect the existing implementation for implicit assumptions, duplicate helpers, and outdated
+   patterns.
+3. Apply the smallest change that improves correctness, readability, and long-term maintainability.
+4. Validate the result against the relevant showcase app path and repo benchmarks.
+5. Hand off adjacent work to the next specialized skill only after the core foundation is stable.
+
+## Guardrails
+
+- Prefer official Android and Kotlin guidance over custom local conventions when they conflict.
+- Keep public APIs boring and explicit; avoid clever abstractions that hide Android lifecycle costs.
+- Do not mix architectural cleanup with product behavior changes unless the request explicitly needs
+  both.
+- Document any compatibility constraints that will affect old modules or generated code.
+
+## Anti-Patterns
+
+- Sprinkling helpers across modules without a clear ownership boundary.
+- Introducing framework-specific code into pure domain or data layers.
+- Refactoring every adjacent file when only one contract needed to change.
+- Leaving migration notes implied instead of writing them down.
+
+## Examples
+
+### Happy path
+
+- Scenario: Tighten domain and UI state models with sealed interfaces and immutable data.
+- Command: `cd examples/orbittasks-compose && ./gradlew :app:testDebugUnitTest`
+
+### Edge case
+
+- Scenario: Guard nullable platform values crossing the XML activity boundary.
+- Command: `cd examples/orbittasks-xml && ./gradlew :app:testDebugUnitTest`
+
+### Failure recovery
+
+- Scenario: Refactor broad helper objects into focused extensions without breaking call sites.
+- Command: `python3 scripts/eval_triggers.py --skill android-kotlin-core`
+
+## Done Checklist
+
+- The implementation path is explicit, minimal, and tied to the right Android surface.
+- Relevant example commands and benchmark prompts have been exercised or updated.
+- Handoffs to adjacent skills are documented when the request crosses boundaries.
+- Official references cover the chosen pattern and the main migration or troubleshooting path.
+
+## Official References
+
+- [https://developer.android.com/kotlin](https://developer.android.com/kotlin)
+- [https://developer.android.com/build/kotlin-support](https://developer.android.com/build/kotlin-support)
+- [https://kotlinlang.org/docs/coding-conventions.html](https://kotlinlang.org/docs/coding-conventions.html)
+- [https://kotlinlang.org/docs/null-safety.html](https://kotlinlang.org/docs/null-safety.html)

--- a/.claude/skills/android-kotlin-core/agents/openai.yaml
+++ b/.claude/skills/android-kotlin-core/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Android Kotlin Core"
+  short_description: "Use Kotlin idioms safely in Android apps, including nullability, data classes, sealed types, extension functions, and collection pipelines"
+  default_prompt: "Use $android-kotlin-core when the request is about use Kotlin idioms safely in Android apps, including nullability, data classes, sealed types, extension functions, and collection pipelines."

--- a/.claude/skills/android-kotlin-core/references/official-links.md
+++ b/.claude/skills/android-kotlin-core/references/official-links.md
@@ -1,0 +1,6 @@
+# Android Kotlin Core Official Links
+
+- [https://developer.android.com/kotlin](https://developer.android.com/kotlin)
+- [https://developer.android.com/build/kotlin-support](https://developer.android.com/build/kotlin-support)
+- [https://kotlinlang.org/docs/coding-conventions.html](https://kotlinlang.org/docs/coding-conventions.html)
+- [https://kotlinlang.org/docs/null-safety.html](https://kotlinlang.org/docs/null-safety.html)

--- a/.claude/skills/android-kotlin-core/references/patterns.md
+++ b/.claude/skills/android-kotlin-core/references/patterns.md
@@ -1,0 +1,23 @@
+# Android Kotlin Core Patterns
+
+## Selection Notes
+
+- Category: `foundations`
+- Best fit when the request matches the trigger language in `SKILL.md` and the implementation focus
+  is
+  `Use Kotlin idioms safely in Android apps, including nullability, data classes, sealed types, extension functions, and collection pipelines.`
+- Reach for neighboring skills only after this skill has framed the main problem.
+
+## Default Review Sequence
+
+1. Map the request to the current Android stack, module boundaries, and minimum supported API level.
+2. Inspect the existing implementation for implicit assumptions, duplicate helpers, and outdated
+   patterns.
+3. Apply the smallest change that improves correctness, readability, and long-term maintainability.
+4. Validate the result against the relevant showcase app path and repo benchmarks.
+5. Hand off adjacent work to the next specialized skill only after the core foundation is stable.
+
+## Handoff Shortlist
+
+- `android-state-management`
+- `android-testing-unit`

--- a/.claude/skills/android-kotlin-core/references/scenarios.md
+++ b/.claude/skills/android-kotlin-core/references/scenarios.md
@@ -1,0 +1,16 @@
+# Android Kotlin Core Runnable Scenarios
+
+## Happy path
+
+- Goal: Tighten domain and UI state models with sealed interfaces and immutable data.
+- Command: `cd examples/orbittasks-compose && ./gradlew :app:testDebugUnitTest`
+
+## Edge case
+
+- Goal: Guard nullable platform values crossing the XML activity boundary.
+- Command: `cd examples/orbittasks-xml && ./gradlew :app:testDebugUnitTest`
+
+## Failure recovery
+
+- Goal: Refactor broad helper objects into focused extensions without breaking call sites.
+- Command: `python3 scripts/eval_triggers.py --skill android-kotlin-core`

--- a/.claude/skills/android-kotlin-core/scripts/run_examples.sh
+++ b/.claude/skills/android-kotlin-core/scripts/run_examples.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+    set -euo pipefail
+
+    cat <<'EOF'
+    Skill: Android Kotlin Core
+    Canonical path: skills/android-kotlin-core
+    Example commands:
+    Happy path: cd examples/orbittasks-compose && ./gradlew :app:testDebugUnitTest
+Edge case: cd examples/orbittasks-xml && ./gradlew :app:testDebugUnitTest
+Failure recovery: python3 scripts/eval_triggers.py --skill android-kotlin-core
+    EOF

--- a/.claude/skills/android-networking-retrofit-okhttp/SKILL.md
+++ b/.claude/skills/android-networking-retrofit-okhttp/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: "android-networking-retrofit-okhttp"
+description: "Build Android networking stacks with Retrofit, OkHttp, interceptors, API contracts, and resilient error handling."
+metadata:
+  version: "0.1.0"
+  category: "data-platform"
+  tags: ["android", "networking", "retrofit", "okhttp"]
+  triggers:
+    include: ["retrofit android setup", "okhttp interceptor android", "api error mapping android", "network client cleanup android", "retry timeout android api"]
+    exclude: ["fragment back stack", "compose semantics", "play store notes"]
+  owners: ["@android-agent-skills/maintainers"]
+  test_targets: ["examples/orbittasks-compose", "examples/orbittasks-xml", "benchmarks/triggers.jsonl"]
+---
+
+# Android Networking Retrofit OkHttp
+
+## When To Use
+
+- Use this skill when the request is about: retrofit android setup, okhttp interceptor android, api
+  error mapping android.
+- Primary outcome: Build Android networking stacks with Retrofit, OkHttp, interceptors, API
+  contracts, and resilient error handling.
+- Handoff skills when the scope expands:
+- `android-serialization-offline-sync`
+- `android-security-best-practices`
+
+## Workflow
+
+1. Confirm the data source, persistence boundary, sync model, and device capability involved.
+2. Model contracts explicitly before wiring network, storage, media, or background APIs.
+3. Apply the recommended AndroidX or platform pattern with migration-safe defaults.
+4. Validate offline, retry, and process death behavior against the sample apps and scenarios.
+5. Escalate security, performance, or release risk to the linked supporting skills when needed.
+
+## Guardrails
+
+- Prefer typed models and explicit serializers over ad-hoc maps or bundles.
+- Keep background work idempotent and cancellation-aware.
+- Do not leak storage, media, or networking details into presentation code.
+- Treat user data durability, privacy, and migration paths as part of the implementation.
+
+## Anti-Patterns
+
+- Blocking the main thread with disk or network calls.
+- Treating retryable sync failures as terminal user-facing errors.
+- Mixing cache models and wire models without a mapping layer.
+- Requesting broad storage or notification capabilities when a narrower API exists.
+
+## Examples
+
+### Happy path
+
+- Scenario: Model sync requests and network failures for task refresh.
+- Command: `cd examples/orbittasks-compose && ./gradlew :app:testDebugUnitTest`
+
+### Edge case
+
+- Scenario: Handle stale cache and retry behavior in the XML fixture.
+- Command: `cd examples/orbittasks-xml && ./gradlew :app:testDebugUnitTest`
+
+### Failure recovery
+
+- Scenario: Differentiate networking prompts from serialization, security, and offline-sync
+  requests.
+- Command: `python3 scripts/eval_triggers.py --skill android-networking-retrofit-okhttp`
+
+## Done Checklist
+
+- The implementation path is explicit, minimal, and tied to the right Android surface.
+- Relevant example commands and benchmark prompts have been exercised or updated.
+- Handoffs to adjacent skills are documented when the request crosses boundaries.
+- Official references cover the chosen pattern and the main migration or troubleshooting path.
+
+## Official References
+
+- [https://developer.android.com/develop/connectivity/network-ops/connecting](https://developer.android.com/develop/connectivity/network-ops/connecting)
+- [https://developer.android.com/topic/architecture/data-layer/offline-first](https://developer.android.com/topic/architecture/data-layer/offline-first)
+- [https://developer.android.com/training/volley](https://developer.android.com/training/volley)
+- [https://developer.android.com/training/articles/perf-anr](https://developer.android.com/training/articles/perf-anr)

--- a/.claude/skills/android-networking-retrofit-okhttp/agents/openai.yaml
+++ b/.claude/skills/android-networking-retrofit-okhttp/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Android Networking Retrofit OkHttp"
+  short_description: "Build Android networking stacks with Retrofit, OkHttp, interceptors, API contracts, and resilient error handling"
+  default_prompt: "Use $android-networking-retrofit-okhttp when the request is about build Android networking stacks with Retrofit, OkHttp, interceptors, API contracts, and resilient error handling."

--- a/.claude/skills/android-networking-retrofit-okhttp/references/official-links.md
+++ b/.claude/skills/android-networking-retrofit-okhttp/references/official-links.md
@@ -1,0 +1,6 @@
+# Android Networking Retrofit OkHttp Official Links
+
+- [https://developer.android.com/develop/connectivity/network-ops/connecting](https://developer.android.com/develop/connectivity/network-ops/connecting)
+- [https://developer.android.com/topic/architecture/data-layer/offline-first](https://developer.android.com/topic/architecture/data-layer/offline-first)
+- [https://developer.android.com/training/volley](https://developer.android.com/training/volley)
+- [https://developer.android.com/training/articles/perf-anr](https://developer.android.com/training/articles/perf-anr)

--- a/.claude/skills/android-networking-retrofit-okhttp/references/patterns.md
+++ b/.claude/skills/android-networking-retrofit-okhttp/references/patterns.md
@@ -1,0 +1,22 @@
+# Android Networking Retrofit OkHttp Patterns
+
+## Selection Notes
+
+- Category: `data-platform`
+- Best fit when the request matches the trigger language in `SKILL.md` and the implementation focus
+  is
+  `Build Android networking stacks with Retrofit, OkHttp, interceptors, API contracts, and resilient error handling.`
+- Reach for neighboring skills only after this skill has framed the main problem.
+
+## Default Review Sequence
+
+1. Confirm the data source, persistence boundary, sync model, and device capability involved.
+2. Model contracts explicitly before wiring network, storage, media, or background APIs.
+3. Apply the recommended AndroidX or platform pattern with migration-safe defaults.
+4. Validate offline, retry, and process death behavior against the sample apps and scenarios.
+5. Escalate security, performance, or release risk to the linked supporting skills when needed.
+
+## Handoff Shortlist
+
+- `android-serialization-offline-sync`
+- `android-security-best-practices`

--- a/.claude/skills/android-networking-retrofit-okhttp/references/scenarios.md
+++ b/.claude/skills/android-networking-retrofit-okhttp/references/scenarios.md
@@ -1,0 +1,16 @@
+# Android Networking Retrofit OkHttp Runnable Scenarios
+
+## Happy path
+
+- Goal: Model sync requests and network failures for task refresh.
+- Command: `cd examples/orbittasks-compose && ./gradlew :app:testDebugUnitTest`
+
+## Edge case
+
+- Goal: Handle stale cache and retry behavior in the XML fixture.
+- Command: `cd examples/orbittasks-xml && ./gradlew :app:testDebugUnitTest`
+
+## Failure recovery
+
+- Goal: Differentiate networking prompts from serialization, security, and offline-sync requests.
+- Command: `python3 scripts/eval_triggers.py --skill android-networking-retrofit-okhttp`

--- a/.claude/skills/android-networking-retrofit-okhttp/scripts/run_examples.sh
+++ b/.claude/skills/android-networking-retrofit-okhttp/scripts/run_examples.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+    set -euo pipefail
+
+    cat <<'EOF'
+    Skill: Android Networking Retrofit OkHttp
+    Canonical path: skills/android-networking-retrofit-okhttp
+    Example commands:
+    Happy path: cd examples/orbittasks-compose && ./gradlew :app:testDebugUnitTest
+Edge case: cd examples/orbittasks-xml && ./gradlew :app:testDebugUnitTest
+Failure recovery: python3 scripts/eval_triggers.py --skill android-networking-retrofit-okhttp
+    EOF

--- a/.claude/skills/android-testing-unit/SKILL.md
+++ b/.claude/skills/android-testing-unit/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: "android-testing-unit"
+description: "Write fast, focused Android unit tests for reducers, use cases, repositories, and lifecycle-safe state holders."
+metadata:
+  version: "0.1.0"
+  category: "quality-release"
+  tags: ["android", "testing", "unit-tests", "verification"]
+  triggers:
+    include: ["android unit test strategy", "test viewmodel reducer android", "repository unit tests android", "mock coroutine dependency android", "fast test coverage android"]
+    exclude: ["ui screenshot only", "play store listing", "apk alignment"]
+  owners: ["@android-agent-skills/maintainers"]
+  test_targets: ["examples/orbittasks-compose", "examples/orbittasks-xml", "benchmarks/triggers.jsonl"]
+---
+
+# Android Testing Unit
+
+## When To Use
+
+- Use this skill when the request is about: android unit test strategy, test viewmodel reducer
+  android, repository unit tests android.
+- Primary outcome: Write fast, focused Android unit tests for reducers, use cases, repositories, and
+  lifecycle-safe state holders.
+- Handoff skills when the scope expands:
+- `android-testing-ui`
+- `android-ui-states-validation`
+
+## Workflow
+
+1. Scope the risk surface: correctness, security, performance, test depth, or release automation.
+2. Pick the narrowest verification strategy that still catches the likely regressions.
+3. Instrument the workflow so failures are actionable rather than just red.
+4. Run the relevant checks on the showcase apps and packaging outputs.
+5. Capture any residual risk with explicit follow-up work and owner skills.
+
+## Guardrails
+
+- Prefer reproducible checks in CI over one-off local heroics.
+- Fail with a precise remediation path instead of a vague quality gate.
+- Keep secrets, signing material, and production credentials out of examples and fixtures.
+- Treat performance and security work as engineering tasks with evidence, not folklore.
+
+## Anti-Patterns
+
+- Adding more tests without increasing signal.
+- Shipping benchmarks or security scans that no one can reproduce.
+- Hard-coding release credentials into build logic.
+- Using synthetic metrics with no user-impact interpretation.
+
+## Examples
+
+### Happy path
+
+- Scenario: Cover reducer and formatter logic in both fixture apps with focused local tests.
+- Command:
+  `cd examples/orbittasks-compose && ./gradlew :app:testDebugUnitTest && cd ../orbittasks-xml && ./gradlew :app:testDebugUnitTest`
+
+### Edge case
+
+- Scenario: Mock sync failures and permission-denied branches without instrumentation.
+- Command: `cd examples/orbittasks-compose && ./gradlew :app:testDebugUnitTest`
+
+### Failure recovery
+
+- Scenario: Separate unit-testing requests from UI testing or general architecture cleanup.
+- Command: `python3 scripts/eval_triggers.py --skill android-testing-unit`
+
+## Done Checklist
+
+- The implementation path is explicit, minimal, and tied to the right Android surface.
+- Relevant example commands and benchmark prompts have been exercised or updated.
+- Handoffs to adjacent skills are documented when the request crosses boundaries.
+- Official references cover the chosen pattern and the main migration or troubleshooting path.
+
+## Official References
+
+- [https://developer.android.com/training/testing/local-tests](https://developer.android.com/training/testing/local-tests)
+- [https://developer.android.com/training/testing/fundamentals](https://developer.android.com/training/testing/fundamentals)
+- [https://developer.android.com/topic/libraries/architecture/viewmodel](https://developer.android.com/topic/libraries/architecture/viewmodel)
+- [https://kotlinlang.org/docs/jvm-test-using-junit.html](https://kotlinlang.org/docs/jvm-test-using-junit.html)

--- a/.claude/skills/android-testing-unit/agents/openai.yaml
+++ b/.claude/skills/android-testing-unit/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Android Testing Unit"
+  short_description: "Write fast, focused Android unit tests for reducers, use cases, repositories, and lifecycle-safe state holders"
+  default_prompt: "Use $android-testing-unit when the request is about write fast, focused Android unit tests for reducers, use cases, repositories, and lifecycle-safe state holders."

--- a/.claude/skills/android-testing-unit/references/official-links.md
+++ b/.claude/skills/android-testing-unit/references/official-links.md
@@ -1,0 +1,6 @@
+# Android Testing Unit Official Links
+
+- [https://developer.android.com/training/testing/local-tests](https://developer.android.com/training/testing/local-tests)
+- [https://developer.android.com/training/testing/fundamentals](https://developer.android.com/training/testing/fundamentals)
+- [https://developer.android.com/topic/libraries/architecture/viewmodel](https://developer.android.com/topic/libraries/architecture/viewmodel)
+- [https://kotlinlang.org/docs/jvm-test-using-junit.html](https://kotlinlang.org/docs/jvm-test-using-junit.html)

--- a/.claude/skills/android-testing-unit/references/patterns.md
+++ b/.claude/skills/android-testing-unit/references/patterns.md
@@ -1,0 +1,22 @@
+# Android Testing Unit Patterns
+
+## Selection Notes
+
+- Category: `quality-release`
+- Best fit when the request matches the trigger language in `SKILL.md` and the implementation focus
+  is
+  `Write fast, focused Android unit tests for reducers, use cases, repositories, and lifecycle-safe state holders.`
+- Reach for neighboring skills only after this skill has framed the main problem.
+
+## Default Review Sequence
+
+1. Scope the risk surface: correctness, security, performance, test depth, or release automation.
+2. Pick the narrowest verification strategy that still catches the likely regressions.
+3. Instrument the workflow so failures are actionable rather than just red.
+4. Run the relevant checks on the showcase apps and packaging outputs.
+5. Capture any residual risk with explicit follow-up work and owner skills.
+
+## Handoff Shortlist
+
+- `android-testing-ui`
+- `android-ui-states-validation`

--- a/.claude/skills/android-testing-unit/references/scenarios.md
+++ b/.claude/skills/android-testing-unit/references/scenarios.md
@@ -1,0 +1,17 @@
+# Android Testing Unit Runnable Scenarios
+
+## Happy path
+
+- Goal: Cover reducer and formatter logic in both fixture apps with focused local tests.
+- Command:
+  `cd examples/orbittasks-compose && ./gradlew :app:testDebugUnitTest && cd ../orbittasks-xml && ./gradlew :app:testDebugUnitTest`
+
+## Edge case
+
+- Goal: Mock sync failures and permission-denied branches without instrumentation.
+- Command: `cd examples/orbittasks-compose && ./gradlew :app:testDebugUnitTest`
+
+## Failure recovery
+
+- Goal: Separate unit-testing requests from UI testing or general architecture cleanup.
+- Command: `python3 scripts/eval_triggers.py --skill android-testing-unit`

--- a/.claude/skills/android-testing-unit/scripts/run_examples.sh
+++ b/.claude/skills/android-testing-unit/scripts/run_examples.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+    set -euo pipefail
+
+    cat <<'EOF'
+    Skill: Android Testing Unit
+    Canonical path: skills/android-testing-unit
+    Example commands:
+    Happy path: cd examples/orbittasks-compose && ./gradlew :app:testDebugUnitTest && cd ../orbittasks-xml && ./gradlew :app:testDebugUnitTest
+Edge case: cd examples/orbittasks-compose && ./gradlew :app:testDebugUnitTest
+Failure recovery: python3 scripts/eval_triggers.py --skill android-testing-unit
+    EOF

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,6 +15,8 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme.Starting"
+        android:fullBackupContent="@xml/backup_rules"
+        android:dataExtractionRules="@xml/data_extraction_rules"
         tools:targetApi="n">
 
         <meta-data

--- a/app/src/main/java/cl/figonzal/lastquakechile/core/services/notifications/QuakeNotification.kt
+++ b/app/src/main/java/cl/figonzal/lastquakechile/core/services/notifications/QuakeNotification.kt
@@ -4,7 +4,5 @@ import com.google.firebase.messaging.RemoteMessage
 
 interface QuakeNotification {
     fun createChannel()
-    fun deleteChannel()
-    fun recreateChannel()
     fun handleQuakeNotification(remoteMessage: RemoteMessage)
 }

--- a/app/src/main/java/cl/figonzal/lastquakechile/core/services/notifications/QuakeNotificationImpl.kt
+++ b/app/src/main/java/cl/figonzal/lastquakechile/core/services/notifications/QuakeNotificationImpl.kt
@@ -12,6 +12,8 @@ import androidx.core.app.NotificationCompat.Builder
 import androidx.core.app.NotificationCompat.VISIBILITY_PUBLIC
 import androidx.core.app.TaskStackBuilder
 import cl.figonzal.lastquakechile.R
+import cl.figonzal.lastquakechile.core.services.notifications.utils.CHANNEL_ID_DEFAULT
+import cl.figonzal.lastquakechile.core.services.notifications.utils.CHANNEL_ID_HIGH
 import cl.figonzal.lastquakechile.core.services.notifications.utils.CITY
 import cl.figonzal.lastquakechile.core.services.notifications.utils.DEPTH
 import cl.figonzal.lastquakechile.core.services.notifications.utils.FIREBASE_CHANNEL_STATUS
@@ -22,19 +24,16 @@ import cl.figonzal.lastquakechile.core.services.notifications.utils.LONGITUDE
 import cl.figonzal.lastquakechile.core.services.notifications.utils.MAGNITUDE
 import cl.figonzal.lastquakechile.core.services.notifications.utils.QUAKE
 import cl.figonzal.lastquakechile.core.services.notifications.utils.QUAKE_CODE
-import cl.figonzal.lastquakechile.core.services.notifications.utils.RANDOM_CHANNEL_ID
+import cl.figonzal.lastquakechile.core.services.notifications.utils.RANDOM_CHANNEL_ID_LEGACY
 import cl.figonzal.lastquakechile.core.services.notifications.utils.REFERENCE
 import cl.figonzal.lastquakechile.core.services.notifications.utils.ROOT_PREF_HIGH_PRIORITY_NOTIFICATION
 import cl.figonzal.lastquakechile.core.services.notifications.utils.ROOT_PREF_QUAKE_PRELIMINARY
 import cl.figonzal.lastquakechile.core.services.notifications.utils.SCALE
 import cl.figonzal.lastquakechile.core.services.notifications.utils.STATE
 import cl.figonzal.lastquakechile.core.services.notifications.utils.UTC_DATE
-import cl.figonzal.lastquakechile.core.services.notifications.utils.generateRandomChannelId
-import cl.figonzal.lastquakechile.core.services.notifications.utils.getChannelImportance
 import cl.figonzal.lastquakechile.core.services.notifications.utils.getMinMagnitude
 import cl.figonzal.lastquakechile.core.services.notifications.utils.getNotificationPriority
 import cl.figonzal.lastquakechile.core.services.notifications.utils.getPreliminaryAlertsStatus
-import cl.figonzal.lastquakechile.core.services.notifications.utils.getRandomChannel
 import cl.figonzal.lastquakechile.core.services.notifications.utils.greaterThan
 import cl.figonzal.lastquakechile.core.utils.SharedPrefUtil
 import cl.figonzal.lastquakechile.core.utils.localDateTimeToString
@@ -57,54 +56,45 @@ class QuakeNotificationImpl(
 
     private val crashlytics = FirebaseCrashlytics.getInstance()
 
+    /**
+     * Creates both fixed notification channels (idempotent — Android ignores duplicates).
+     * Also migrates any legacy random channel left by the old scheme.
+     */
     @RequiresApi(api = Build.VERSION_CODES.O)
     override fun createChannel() {
+        migrateLegacyChannel()
 
-        val randomChannel = generateRandomChannelId(sharedPrefUtil, RANDOM_CHANNEL_ID)
+        val notificationManager = context.getSystemService(NotificationManager::class.java)
 
-        val name = context.getString(R.string.firebase_channel_name_quakes)
-        val description = context.getString(R.string.firebase_channel_description_quakes)
+        val highName = context.getString(R.string.firebase_channel_name_quakes_high)
+        val highDesc = context.getString(R.string.firebase_channel_description_quakes_high)
+        NotificationChannel(CHANNEL_ID_HIGH, highName, NotificationManager.IMPORTANCE_HIGH).apply {
+            description = highDesc
+            enableLights(true)
+            lightColor = R.color.colorSecondary
+        }.also { notificationManager.createNotificationChannel(it) }
 
-        val importance =
-            getChannelImportance(sharedPrefUtil, ROOT_PREF_HIGH_PRIORITY_NOTIFICATION, crashlytics)
+        val defaultName = context.getString(R.string.firebase_channel_name_quakes_default)
+        val defaultDesc = context.getString(R.string.firebase_channel_description_quakes_default)
+        NotificationChannel(CHANNEL_ID_DEFAULT, defaultName, NotificationManager.IMPORTANCE_DEFAULT).apply {
+            description = defaultDesc
+            enableLights(true)
+            lightColor = R.color.colorSecondary
+        }.also { notificationManager.createNotificationChannel(it) }
 
-        context.getSystemService(NotificationManager::class.java).apply {
-
-            createNotificationChannel(
-                NotificationChannel(
-                    randomChannel.toString(),
-                    name,
-                    importance
-                ).apply {
-                    this.description = description
-                    this.importance = importance
-                    this.enableLights(true)
-                    this.lightColor = R.color.colorSecondary
-
-                    Timber.d("Notification channel created")
-                    crashlytics.setCustomKey(FIREBASE_CHANNEL_STATUS, "Created")
-                }
-            )
-        }
+        Timber.d("Notification channels created/verified")
+        crashlytics.setCustomKey(FIREBASE_CHANNEL_STATUS, "Created")
     }
 
     @RequiresApi(Build.VERSION_CODES.O)
-    override fun deleteChannel() {
-
-        val randomChannel = getRandomChannel(sharedPrefUtil, RANDOM_CHANNEL_ID)
-
-        context.getSystemService(NotificationManager::class.java).apply {
-            deleteNotificationChannel(randomChannel.toString())
-
-            Timber.d("Notification channel deleted")
-            crashlytics.setCustomKey(FIREBASE_CHANNEL_STATUS, "Deleted")
+    private fun migrateLegacyChannel() {
+        val legacyId = sharedPrefUtil.getData(RANDOM_CHANNEL_ID_LEGACY, 0)
+        if (legacyId != 0) {
+            context.getSystemService(NotificationManager::class.java)
+                .deleteNotificationChannel(legacyId.toString())
+            sharedPrefUtil.saveData(RANDOM_CHANNEL_ID_LEGACY, 0)
+            Timber.d("Migrated legacy notification channel: $legacyId")
         }
-    }
-
-    @RequiresApi(Build.VERSION_CODES.O)
-    override fun recreateChannel() {
-        deleteChannel()
-        createChannel()
     }
 
     /**
@@ -185,7 +175,7 @@ class QuakeNotificationImpl(
         pendingIntent: PendingIntent
     ) {
 
-        val randomChannel = getRandomChannel(sharedPrefUtil, RANDOM_CHANNEL_ID)
+        val channelId = resolveChannelId()
 
         val preliminaryNotifications = getPreliminaryAlertsStatus(
             sharedPrefUtil, ROOT_PREF_QUAKE_PRELIMINARY, crashlytics
@@ -205,10 +195,8 @@ class QuakeNotificationImpl(
                 crashlytics
             )
 
-        Builder(
-            context,
-            randomChannel.toString()
-        ).setSmallIcon(R.drawable.lastquakechile_400)
+        Builder(context, channelId)
+            .setSmallIcon(R.drawable.lastquakechile_400)
             .setContentTitle(title)
             .setContentText(description)
             .setStyle(BigTextStyle().bigText(description))
@@ -234,12 +222,10 @@ class QuakeNotificationImpl(
      */
     fun handleNotificationGeneric(remoteMessage: RemoteMessage) {
 
-        val randomChannel = getRandomChannel(sharedPrefUtil, RANDOM_CHANNEL_ID)
+        val channelId = resolveChannelId()
 
-        Builder(
-            context,
-            randomChannel.toString()
-        ).setContentTitle(remoteMessage.notification?.title)
+        Builder(context, channelId)
+            .setContentTitle(remoteMessage.notification?.title)
             .setContentText(remoteMessage.notification?.body)
             .setStyle(BigTextStyle().bigText(remoteMessage.notification?.body))
             .setSmallIcon(R.drawable.lastquakechile_400)
@@ -247,10 +233,16 @@ class QuakeNotificationImpl(
             .setVisibility(VISIBILITY_PUBLIC)
             .also {
                 (context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager).notify(
-                    randomChannel,
+                    (System.currentTimeMillis() % Int.MAX_VALUE).toInt(),
                     it.build()
                 )
             }
+    }
+
+    /** Returns the channel ID to use for an incoming notification based on current preference. */
+    private fun resolveChannelId(): String {
+        val highPriority = sharedPrefUtil.getData(ROOT_PREF_HIGH_PRIORITY_NOTIFICATION, true)
+        return if (highPriority) CHANNEL_ID_HIGH else CHANNEL_ID_DEFAULT
     }
 
     /**

--- a/app/src/main/java/cl/figonzal/lastquakechile/core/services/notifications/utils/Constants.kt
+++ b/app/src/main/java/cl/figonzal/lastquakechile/core/services/notifications/utils/Constants.kt
@@ -12,13 +12,20 @@ internal const val FIREBASE_MSG_GENERIC = "generic_msg_received"
 internal const val FIREBASE_SUB_QUAKE = "subscribed_quake"
 internal const val FIREBASE_TOPIC_CHANNEL = "quakes_v2"
 
-//Other constants
-internal const val RANDOM_CHANNEL_ID = "random_channel_id"
+//Notification channel IDs (fixed, coexisting)
+internal const val CHANNEL_ID_HIGH = "quakes_high"
+internal const val CHANNEL_ID_DEFAULT = "quakes_default"
+
+//Legacy key — used only during migration from random channel scheme
+internal const val RANDOM_CHANNEL_ID_LEGACY = "random_channel_id"
 const val MIN_MAGNITUDE_ALERT = "1.0"
 
 //ANDROID > 13 permission request for notifications
 internal const val SHARED_PREF_PERMISSION_ALERT_ANDROID_13 = "alert_permission_granted"
 internal const val SHARED_HIDE_ALERT_PERMISSION_CV = "hide_alert_cv"
+// Tracks whether POST_NOTIFICATIONS was ever requested at least once, so we can distinguish
+// "never asked" (should show system dialog) from "permanently denied" (should open Settings).
+internal const val SHARED_PREF_PERMISSION_ASKED_ONCE = "post_notifications_asked"
 
 //JSON KEYS
 const val QUAKE = "quake"

--- a/app/src/main/java/cl/figonzal/lastquakechile/core/services/notifications/utils/NotificationsExt.kt
+++ b/app/src/main/java/cl/figonzal/lastquakechile/core/services/notifications/utils/NotificationsExt.kt
@@ -51,7 +51,14 @@ fun setUpNotificationService(
     }
 
     if (notificationsEnabled) {
-        subscribedToQuakes(true, sharedPrefUtil)
+        // Respect the user's persisted preference — re-subscribing on every cold start would
+        // override an explicit OFF toggle the user made in Settings.
+        val userWantsAlerts = sharedPrefUtil.getData(ROOT_PREF_SUBSCRIPTION, true)
+        if (userWantsAlerts) {
+            subscribedToQuakes(true)
+        } else {
+            Timber.d("User opted out of alerts — skipping FCM subscription")
+        }
     } else {
         Timber.d("POST_NOTIFICATIONS not granted — skipping FCM subscription")
     }
@@ -82,8 +89,18 @@ fun Fragment.handleCvAlertPermission(
     ) == PackageManager.PERMISSION_GRANTED
 
     if (isGranted) {
+        // Detect the "just granted from Settings" transition: if the card was visible (or its
+        // initial INVISIBLE/default state) right before this call, FCM wasn't subscribed at boot
+        // because permission was missing. Subscribe now so the topic is registered without
+        // requiring an app restart.
+        val wasShowingCard = binding.cvAlertPermission.root.visibility != View.GONE
         binding.cvAlertPermission.root.visibility = View.GONE
         sharedPrefUtil.saveData(SHARED_PREF_PERMISSION_ALERT_ANDROID_13, true)
+        // Subscribe only on the denied → granted transition AND if the user wants alerts.
+        // Re-evaluating on every onResume would otherwise hit FCM with no actual state change.
+        if (wasShowingCard && sharedPrefUtil.getData(ROOT_PREF_SUBSCRIPTION, true)) {
+            subscribedToQuakes(true)
+        }
         return
     }
 
@@ -130,7 +147,7 @@ fun Fragment.onNotificationPermissionResult(
         Timber.d("POST_NOTIFICATIONS granted")
         toast(R.string.notification_permission_on)
         sharedPrefUtil.saveData(SHARED_PREF_PERMISSION_ALERT_ANDROID_13, true)
-        subscribedToQuakes(true, sharedPrefUtil)
+        subscribedToQuakes(true)
     } else {
         Timber.d("POST_NOTIFICATIONS denied")
         toast(R.string.notification_permission_off)
@@ -169,14 +186,14 @@ fun getFirebaseToken() {
  *
  * @param isSubscribed
  */
-fun subscribedToQuakes(
-    isSubscribed: Boolean,
-    sharedPrefUtil: SharedPrefUtil,
-) {
+fun subscribedToQuakes(isSubscribed: Boolean) {
 
     val fcm = Firebase.messaging
     val crashlytics = Firebase.crashlytics
 
+    // Persistence of the user's preference is owned by SwitchPreferenceCompat (bound to the
+    // "pref_suscrito_quake" key). This function is a pure FCM side-effect — writing here would
+    // shadow that same key and corrupt the switch state.
     when {
         isSubscribed -> {
 
@@ -184,13 +201,8 @@ fun subscribedToQuakes(
                 .addOnCompleteListener {
                     when {
                         it.isSuccessful -> {
-
-                            with(true) {
-                                sharedPrefUtil.saveData(ROOT_PREF_SUBSCRIPTION, this)
-
-                                Timber.d("Subscribed to topic")
-                                crashlytics.setCustomKey(FIREBASE_SUB_QUAKE, this)
-                            }
+                            Timber.d("Subscribed to topic")
+                            crashlytics.setCustomKey(FIREBASE_SUB_QUAKE, true)
                         }
                     }
                 }
@@ -201,13 +213,8 @@ fun subscribedToQuakes(
                 .addOnCompleteListener {
                     when {
                         it.isSuccessful -> {
-
-                            with(false) {
-                                sharedPrefUtil.saveData(ROOT_PREF_SUBSCRIPTION, this)
-
-                                Timber.d("Subscription deleted")
-                                crashlytics.setCustomKey(FIREBASE_SUB_QUAKE, this)
-                            }
+                            Timber.d("Subscription deleted")
+                            crashlytics.setCustomKey(FIREBASE_SUB_QUAKE, false)
                         }
                     }
                 }

--- a/app/src/main/java/cl/figonzal/lastquakechile/core/services/notifications/utils/NotificationsExt.kt
+++ b/app/src/main/java/cl/figonzal/lastquakechile/core/services/notifications/utils/NotificationsExt.kt
@@ -1,13 +1,13 @@
 package cl.figonzal.lastquakechile.core.services.notifications.utils
 
 import android.Manifest
-import android.app.Activity
-import android.app.NotificationManager
+import android.content.Intent
 import android.content.pm.PackageManager
+import android.net.Uri
 import android.os.Build
+import android.provider.Settings
 import android.view.View
 import androidx.activity.result.ActivityResultLauncher
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.RequiresApi
 import androidx.core.app.NotificationCompat.PRIORITY_DEFAULT
 import androidx.core.app.NotificationCompat.PRIORITY_HIGH
@@ -26,90 +26,123 @@ import com.google.firebase.crashlytics.crashlytics
 import com.google.firebase.messaging.FirebaseMessaging
 import com.google.firebase.messaging.messaging
 import timber.log.Timber
-import java.security.SecureRandom
-import kotlin.random.asKotlinRandom
 
-fun Activity.setUpNotificationService(sharedPrefUtil: SharedPrefUtil) {
-
+/**
+ * Sets up notification channels and subscribes to the FCM topic only if POST_NOTIFICATIONS
+ * is already granted (or the device is below Android 13 where no runtime permission is needed).
+ * The permission request itself is deferred to the in-app cardview in QuakeFragment.
+ */
+fun setUpNotificationService(
+    context: android.content.Context,
+    sharedPrefUtil: SharedPrefUtil
+) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-        QuakeNotificationImpl(this, sharedPrefUtil).createChannel()
+        QuakeNotificationImpl(context, sharedPrefUtil).createChannel()
     }
 
-    //Automatic subscribe
-    subscribedToQuakes(true, sharedPrefUtil)
+    val notificationsEnabled = when {
+        Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU ->
+            ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.POST_NOTIFICATIONS
+            ) == PackageManager.PERMISSION_GRANTED
+
+        else -> true
+    }
+
+    if (notificationsEnabled) {
+        subscribedToQuakes(true, sharedPrefUtil)
+    } else {
+        Timber.d("POST_NOTIFICATIONS not granted — skipping FCM subscription")
+    }
 }
 
+/**
+ * Manages the permission cardview in QuakeFragment.
+ *
+ * Visibility is driven by the real permission state (checkSelfPermission), NOT SharedPreferences,
+ * so the card reappears after a reinstall or revocation regardless of Auto Backup state.
+ *
+ * The [launcher] must be registered by the Fragment before onStart (e.g. as a property).
+ *
+ * Flow:
+ *  - Permission already granted → hide cardview.
+ *  - Not granted, can ask again → show cardview with "Activate" → system dialog.
+ *  - Permanently denied → show cardview with "Open Settings" → system notification settings.
+ */
 @RequiresApi(Build.VERSION_CODES.TIRAMISU)
 fun Fragment.handleCvAlertPermission(
     binding: FragmentQuakeBinding,
-    sharedPrefUtil: SharedPrefUtil
+    sharedPrefUtil: SharedPrefUtil,
+    launcher: ActivityResultLauncher<String>
 ) {
+    val isGranted = ContextCompat.checkSelfPermission(
+        requireContext(),
+        Manifest.permission.POST_NOTIFICATIONS
+    ) == PackageManager.PERMISSION_GRANTED
 
-    val requestPermission = registerForActivityResult(
-        ActivityResultContracts.RequestPermission()
-    ) { isGranted: Boolean ->
-
-        //Called when requestPermission is launch
-        when {
-            isGranted -> {
-                Timber.d("Alert permission granted")
-                toast(R.string.notification_permission_on)
-                sharedPrefUtil.saveData(SHARED_PREF_PERMISSION_ALERT_ANDROID_13, true)
-            }
-
-            else -> {
-                Timber.d("Alert permission not granted")
-                toast(R.string.notification_permission_off)
-                sharedPrefUtil.saveData(SHARED_PREF_PERMISSION_ALERT_ANDROID_13, false)
-            }
-        }
-        sharedPrefUtil.saveData(SHARED_HIDE_ALERT_PERMISSION_CV, true)
+    if (isGranted) {
         binding.cvAlertPermission.root.visibility = View.GONE
+        sharedPrefUtil.saveData(SHARED_PREF_PERMISSION_ALERT_ANDROID_13, true)
+        return
     }
 
-    val showCv = sharedPrefUtil.getData(SHARED_HIDE_ALERT_PERMISSION_CV, false)
+    binding.cvAlertPermission.root.visibility = View.VISIBLE
 
-    if (!showCv) {
+    // shouldShowRequestPermissionRationale() returns false in TWO cases:
+    //   1. Permission was NEVER requested (fresh install) — should show "Activate"
+    //   2. User selected "Don't ask again" (permanently denied) — should show "Open Settings"
+    // We use a persisted flag to distinguish them: if we've never launched the request, case 1.
+    val wasAskedBefore = sharedPrefUtil.getData(SHARED_PREF_PERMISSION_ASKED_ONCE, false)
+    val permanentlyDenied = wasAskedBefore && !shouldShowRequestPermissionRationale(
+        Manifest.permission.POST_NOTIFICATIONS
+    )
 
-        with(binding.cvAlertPermission) {
-            root.visibility = View.VISIBLE
+    with(binding.cvAlertPermission) {
+        if (permanentlyDenied) {
+            btnRequestPermission.setText(R.string.open_settings_button)
             btnRequestPermission.setOnClickListener {
-                launchRequestPermission(
-                    this@handleCvAlertPermission,
-                    sharedPrefUtil,
-                    requestPermission
-                ) {
-                    root.visibility = View.GONE
-                }
+                openNotificationSettings()
+            }
+        } else {
+            btnRequestPermission.setText(R.string.activate_button)
+            btnRequestPermission.setOnClickListener {
+                launcher.launch(Manifest.permission.POST_NOTIFICATIONS)
             }
         }
     }
 }
 
+/**
+ * Called from QuakeFragment after the permission launcher returns a result.
+ * Updates SharedPrefs and subscribes to FCM on grant.
+ */
 @RequiresApi(Build.VERSION_CODES.TIRAMISU)
-fun launchRequestPermission(
-    fragment: Fragment,
-    sharedPrefUtil: SharedPrefUtil,
-    requestPermission: ActivityResultLauncher<String>,
-    hideCardView: () -> Unit
+fun Fragment.onNotificationPermissionResult(
+    isGranted: Boolean,
+    sharedPrefUtil: SharedPrefUtil
 ) {
-    when (PackageManager.PERMISSION_GRANTED) {
-        ContextCompat.checkSelfPermission(
-            fragment.requireContext(),
-            Manifest.permission.POST_NOTIFICATIONS
-        ) -> {
-            Timber.d("Permission already granted for this device")
-            sharedPrefUtil.saveData(SHARED_PREF_PERMISSION_ALERT_ANDROID_13, true)
+    // Mark that the system dialog was shown at least once, so the next call to
+    // handleCvAlertPermission can correctly distinguish "never asked" from "permanently denied".
+    sharedPrefUtil.saveData(SHARED_PREF_PERMISSION_ASKED_ONCE, true)
 
-            //Hide cardview permission
-            sharedPrefUtil.saveData(SHARED_HIDE_ALERT_PERMISSION_CV, true)
-            fragment.toast(R.string.notification_permission_on)
-
-            hideCardView()
-        }
-
-        else -> requestPermission.launch(Manifest.permission.POST_NOTIFICATIONS)
+    if (isGranted) {
+        Timber.d("POST_NOTIFICATIONS granted")
+        toast(R.string.notification_permission_on)
+        sharedPrefUtil.saveData(SHARED_PREF_PERMISSION_ALERT_ANDROID_13, true)
+        subscribedToQuakes(true, sharedPrefUtil)
+    } else {
+        Timber.d("POST_NOTIFICATIONS denied")
+        toast(R.string.notification_permission_off)
+        sharedPrefUtil.saveData(SHARED_PREF_PERMISSION_ALERT_ANDROID_13, false)
     }
+}
+
+private fun Fragment.openNotificationSettings() {
+    val intent = Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS).apply {
+        putExtra(Settings.EXTRA_APP_PACKAGE, requireContext().packageName)
+    }
+    startActivity(intent)
 }
 
 /**
@@ -183,21 +216,6 @@ fun subscribedToQuakes(
     }
 }
 
-fun generateRandomChannelId(
-    sharedPrefUtil: SharedPrefUtil,
-    randomChannelIdKey: String
-): Int {
-
-    val savedRandomChannel = sharedPrefUtil.getData(randomChannelIdKey, 1)
-
-    var newRandomChannel = 1
-    while (savedRandomChannel == newRandomChannel) {
-        newRandomChannel = SecureRandom().asKotlinRandom().nextInt()
-    }
-    sharedPrefUtil.saveData(randomChannelIdKey, newRandomChannel)
-    return newRandomChannel
-}
-
 fun getPreliminaryAlertsStatus(
     sharedPrefUtil: SharedPrefUtil,
     prefQuakePreliminaryKey: String,
@@ -215,33 +233,6 @@ fun getPreliminaryAlertsStatus(
     return isPreliminaryAlerts
 }
 
-fun getRandomChannel(sharedPrefUtil: SharedPrefUtil, randomChannelId: String) =
-    sharedPrefUtil.getData(randomChannelId, 1)
-
-/**
- * Return importance level for channel creation
- */
-@RequiresApi(Build.VERSION_CODES.N)
-fun getChannelImportance(
-    sharedPrefUtil: SharedPrefUtil,
-    prefHighPriorityKey: String,
-    crashlytics: FirebaseCrashlytics
-): Int {
-
-    val highPriority = sharedPrefUtil.getData(prefHighPriorityKey, true)
-
-    Timber.d("$prefHighPriorityKey: $highPriority")
-    crashlytics.setCustomKey(prefHighPriorityKey, highPriority)
-
-    return when {
-        highPriority -> NotificationManager.IMPORTANCE_HIGH
-        else -> NotificationManager.IMPORTANCE_DEFAULT
-    }
-}
-
-/**
- * Return priority level for notification
- */
 fun getNotificationPriority(
     sharedPrefUtil: SharedPrefUtil,
     prefHighPriorityKey: String,

--- a/app/src/main/java/cl/figonzal/lastquakechile/core/ui/MainActivity.kt
+++ b/app/src/main/java/cl/figonzal/lastquakechile/core/ui/MainActivity.kt
@@ -92,7 +92,7 @@ class MainActivity : AppCompatActivity() {
         //Ads
         adView = startAds(binding.adViewContainer)
 
-        setUpNotificationService(sharedPrefUtil)
+        setUpNotificationService(applicationContext, sharedPrefUtil)
 
         //Updater service
         updaterService = UpdaterService(this, activityResultLauncher)

--- a/app/src/main/java/cl/figonzal/lastquakechile/core/ui/SettingsActivity.kt
+++ b/app/src/main/java/cl/figonzal/lastquakechile/core/ui/SettingsActivity.kt
@@ -22,11 +22,10 @@ import androidx.preference.Preference
 import androidx.preference.PreferenceCategory
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.SwitchPreferenceCompat
+import androidx.core.app.NotificationManagerCompat
 import cl.figonzal.lastquakechile.BuildConfig
 import cl.figonzal.lastquakechile.R
-import cl.figonzal.lastquakechile.core.services.notifications.QuakeNotificationImpl
 import cl.figonzal.lastquakechile.core.services.notifications.utils.MIN_MAGNITUDE_ALERT
-import cl.figonzal.lastquakechile.core.services.notifications.utils.SHARED_PREF_PERMISSION_ALERT_ANDROID_13
 import cl.figonzal.lastquakechile.core.services.notifications.utils.subscribedToQuakes
 import cl.figonzal.lastquakechile.core.utils.SharedPrefUtil
 import cl.figonzal.lastquakechile.core.utils.views.toast
@@ -66,9 +65,6 @@ class SettingsActivity : AppCompatActivity() {
     class SettingsFragment : PreferenceFragmentCompat(), OnSharedPreferenceChangeListener {
 
         private val sharedPrefUtil: SharedPrefUtil by lazy { SharedPrefUtil(requireActivity()) }
-        private val notificationServiceImpl by lazy {
-            QuakeNotificationImpl(requireActivity(), sharedPrefUtil)
-        }
 
         override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
             setPreferencesFromResource(R.xml.root_preferences, rootKey)
@@ -115,7 +111,7 @@ class SettingsActivity : AppCompatActivity() {
 
         private fun configNotifications() {
             val isGrantedPermission =
-                sharedPrefUtil.getData(SHARED_PREF_PERMISSION_ALERT_ANDROID_13, true)
+                NotificationManagerCompat.from(requireContext()).areNotificationsEnabled()
 
             when {
                 !isGrantedPermission -> {
@@ -285,13 +281,9 @@ class SettingsActivity : AppCompatActivity() {
             if (key == getString(R.string.high_priority_key)) {
 
                 preferences?.getBoolean(getString(R.string.high_priority_key), true)?.also {
-
-                    //Si el switch esta ON, lanzar toast con SUSCRITO
                     sharedPrefUtil.saveData(getString(R.string.high_priority_key), it)
-
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                        notificationServiceImpl.recreateChannel()
-                    }
+                    // Channel selection (CHANNEL_ID_HIGH vs CHANNEL_ID_DEFAULT) happens at
+                    // notification time via resolveChannelId(), so no channel recreation needed.
                 }
             }
         }

--- a/app/src/main/java/cl/figonzal/lastquakechile/core/ui/SettingsActivity.kt
+++ b/app/src/main/java/cl/figonzal/lastquakechile/core/ui/SettingsActivity.kt
@@ -113,19 +113,30 @@ class SettingsActivity : AppCompatActivity() {
             val isGrantedPermission =
                 NotificationManagerCompat.from(requireContext()).areNotificationsEnabled()
 
-            when {
-                !isGrantedPermission -> {
+            val alertSwitch =
+                findPreference<SwitchPreferenceCompat>(getString(R.string.firebase_pref_key))
+            val category =
+                findPreference<PreferenceCategory>(getString(R.string.notifications_category_key))
 
-                    findPreference<SwitchPreferenceCompat>(getString(R.string.firebase_pref_key))?.apply {
-                        isChecked = false
-                        isEnabled = false
-                    }
-                    findPreference<PreferenceCategory>(getString(R.string.notifications_category_key))?.summary =
-                        getString(R.string.permission_totally_disabled)
-
-                    subscribedToQuakes(false, sharedPrefUtil)
-                    alertDependencies(false)
+            if (!isGrantedPermission) {
+                // OS-level block. Only disable the UI and update the summary. Do NOT touch
+                // isChecked (it would persist false and corrupt the user's preference), and do
+                // NOT call subscribedToQuakes(false) (Android already drops the pushes; the
+                // FCM topic registration is harmless when permission is missing).
+                alertSwitch?.isEnabled = false
+                category?.summary = getString(R.string.permission_totally_disabled)
+                alertDependencies(false)
+            } else {
+                // Permission granted. Re-enable the switch and honor the user's persisted
+                // preference. Re-subscribe in case boot-time subscription was skipped due to
+                // missing permission. subscribedToQuakes is now a pure FCM side-effect and no
+                // longer writes to SharedPrefs, so this cannot corrupt the switch state.
+                alertSwitch?.isEnabled = true
+                val userWantsAlerts = alertSwitch?.isChecked ?: true
+                if (userWantsAlerts) {
+                    subscribedToQuakes(true)
                 }
+                alertDependencies(userWantsAlerts)
             }
         }
 
@@ -261,13 +272,13 @@ class SettingsActivity : AppCompatActivity() {
                     //Si el switch esta ON, lanzar toast con SUSCRITO
                     when (it) {
                         true -> {
-                            subscribedToQuakes(true, sharedPrefUtil)
+                            subscribedToQuakes(true)
                             toast(R.string.firebase_pref_key_alert_on)
                             alertDependencies(true)
                         }
 
                         else -> {
-                            subscribedToQuakes(false, sharedPrefUtil)
+                            subscribedToQuakes(false)
                             toast(R.string.firebase_pref_key_alert_off)
                             alertDependencies(false)
                         }

--- a/app/src/main/java/cl/figonzal/lastquakechile/quake_feature/ui/QuakeFragment.kt
+++ b/app/src/main/java/cl/figonzal/lastquakechile/quake_feature/ui/QuakeFragment.kt
@@ -6,6 +6,8 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.AbsListView
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.DrawableRes
 import androidx.core.content.res.ResourcesCompat
 import androidx.fragment.app.Fragment
@@ -19,6 +21,7 @@ import androidx.recyclerview.widget.RecyclerView
 import cl.figonzal.lastquakechile.R
 import cl.figonzal.lastquakechile.core.data.remote.ApiError
 import cl.figonzal.lastquakechile.core.services.notifications.utils.handleCvAlertPermission
+import cl.figonzal.lastquakechile.core.services.notifications.utils.onNotificationPermissionResult
 import cl.figonzal.lastquakechile.core.utils.SharedPrefUtil
 import cl.figonzal.lastquakechile.core.utils.views.configOptionsMenu
 import cl.figonzal.lastquakechile.core.utils.views.showServerApiError
@@ -38,6 +41,20 @@ class QuakeFragment : Fragment() {
 
     private var _binding: FragmentQuakeBinding? = null
     private val binding get() = _binding!!
+
+    // Must be registered before onStart — fragment property initializer is the correct place.
+    private val notificationPermissionLauncher: ActivityResultLauncher<String> =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted ->
+            _binding?.let { handlePermissionResult(isGranted, it) }
+        }
+
+    private fun handlePermissionResult(isGranted: Boolean, binding: FragmentQuakeBinding) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            val sharedPrefUtil = SharedPrefUtil(requireContext())
+            onNotificationPermissionResult(isGranted, sharedPrefUtil)
+            handleCvAlertPermission(binding, sharedPrefUtil, notificationPermissionLauncher)
+        }
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -74,7 +91,7 @@ class QuakeFragment : Fragment() {
             }
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                handleCvAlertPermission(binding, SharedPrefUtil(requireContext()))
+                handleCvAlertPermission(binding, SharedPrefUtil(requireContext()), notificationPermissionLauncher)
             }
         }
     }

--- a/app/src/main/java/cl/figonzal/lastquakechile/quake_feature/ui/QuakeFragment.kt
+++ b/app/src/main/java/cl/figonzal/lastquakechile/quake_feature/ui/QuakeFragment.kt
@@ -275,6 +275,18 @@ class QuakeFragment : Fragment() {
         }
     }
 
+    override fun onResume() {
+        super.onResume()
+        // Re-evaluate the permission cardview whenever the fragment becomes visible.
+        // Covers the case where the user returns from system Settings after granting/revoking
+        // POST_NOTIFICATIONS — otherwise the card stays stuck on its previous state.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            _binding?.let {
+                handleCvAlertPermission(it, SharedPrefUtil(requireContext()), notificationPermissionLauncher)
+            }
+        }
+    }
+
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -15,6 +15,10 @@
     <string name="cd_sensitive_icon">Sensitive quake icon</string>
     <string name="firebase_channel_name_quakes">Quake alerts</string>
     <string name="firebase_channel_description_quakes">Receives quake alerts</string>
+    <string name="firebase_channel_name_quakes_high">Quake alerts · High priority</string>
+    <string name="firebase_channel_description_quakes_high">Quake alerts with heads-up notification</string>
+    <string name="firebase_channel_name_quakes_default">Quake alerts · Normal priority</string>
+    <string name="firebase_channel_description_quakes_default">Quake alerts shown in status bar</string>
     <string name="west_cords">W</string>
     <string name="east_cords">E</string>
     <string name="cd_quake_list_section">List of quakes section</string>
@@ -138,6 +142,7 @@
     <string name="min_magnitude_dialog_title">Minimum magnitude</string>
     <string name="min_magnitude_dialog_message">Earthquakes greater than … \nExample: 5.6, 3.5, 2.9, etc</string>
     <string name="activate_button">Activate</string>
+    <string name="open_settings_button">Open Settings</string>
     <string name="alert_permission_description">This device requires permissions for earthquake alerts. To receive them, activate the permission for notifications.</string>
     <string name="alert_permission_title">Permission for earthquake alerts</string>
     <string name="privacy_policy">Privacy policy</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -15,6 +15,10 @@
     <string name="cd_sensitive_icon">Icono sismo sensible</string>
     <string name="firebase_channel_name_quakes">Alerta sismos</string>
     <string name="firebase_channel_description_quakes">Recibe alertas de sismos</string>
+    <string name="firebase_channel_name_quakes_high">Alerta sismos · Alta prioridad</string>
+    <string name="firebase_channel_description_quakes_high">Alertas de sismos con notificación emergente</string>
+    <string name="firebase_channel_name_quakes_default">Alerta sismos · Prioridad normal</string>
+    <string name="firebase_channel_description_quakes_default">Alertas de sismos en la barra de notificaciones</string>
     <string name="west_cords">O</string>
     <string name="east_cords">E</string>
     <string name="cd_quake_list_section">Sección listado de sismos</string>
@@ -139,6 +143,7 @@
     <string name="min_magnitude_dialog_title">Magnitud mínima</string>
     <string name="min_magnitude_dialog_message">Sismos mayores que … \nEjemplo: 5.6, 3.5, 2.9, etc.</string>
     <string name="activate_button">Activar</string>
+    <string name="open_settings_button">Ir a Ajustes</string>
     <string name="alert_permission_description">Este dispositivo requiere permisos para las alertas de sismos. Para recibirlas, active el permiso para notificaciones</string>
     <string name="alert_permission_title">Permiso para alertas sísmicas</string>
     <string name="privacy_policy">Política de privacidad</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,6 +24,10 @@
     <!-- FIREBASE strings -->
     <string name="firebase_channel_name_quakes">Quake alerts</string>
     <string name="firebase_channel_description_quakes">Receives quake alerts</string>
+    <string name="firebase_channel_name_quakes_high">Quake alerts · High priority</string>
+    <string name="firebase_channel_description_quakes_high">Quake alerts with heads-up notification</string>
+    <string name="firebase_channel_name_quakes_default">Quake alerts · Normal priority</string>
+    <string name="firebase_channel_description_quakes_default">Quake alerts shown in status bar</string>
     <string name="firebase_pref_key_alert_on">Alerts enabled</string>
     <string name="firebase_pref_key_alert_off">Alerts disabled</string>
     <!-- ROOT PREFERENCES -->
@@ -175,6 +179,7 @@
     <string name="min_magnitude_dialog_title">Minimum magnitude</string>
     <string name="min_magnitude_dialog_message">Earthquakes greater than … \nExample: 5.6, 3.5, 2.9, etc</string>
     <string name="activate_button">Activate</string>
+    <string name="open_settings_button">Open Settings</string>
     <string name="alert_permission_description">This device requires permissions for earthquake alerts. To receive them, activate the permission for notifications.</string>
     <string name="alert_permission_title">Permission for earthquake alerts</string>
     <string name="privacy_policy">Privacy policy</string>

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Auto Backup rules for Android 11 and below.
+    The domain="sharedpref" path must match the SharedPreferences FILE NAME (not key names).
+    SharedPrefUtil uses the file "lastquakechile", so we exclude that entire file to prevent
+    stale notification permission state from being restored on reinstall.
+-->
+<full-backup-content>
+    <exclude domain="sharedpref" path="lastquakechile" />
+</full-backup-content>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Data extraction rules for Android 12+.
+    Excludes the "lastquakechile" SharedPreferences file from cloud backup and device transfer
+    so notification permission state is never restored from a previous install.
+    Note: domain="sharedpref" path must be the SharedPreferences FILE NAME, not a key name.
+-->
+<data-extraction-rules>
+    <cloud-backup>
+        <exclude domain="sharedpref" path="lastquakechile" />
+    </cloud-backup>
+    <device-transfer>
+        <exclude domain="sharedpref" path="lastquakechile" />
+    </device-transfer>
+</data-extraction-rules>

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,45 @@
+{
+  "version": 1,
+  "skills": {
+    "android-architecture-clean": {
+      "source": "krutikJain/android-agent-skills",
+      "sourceType": "autoskills-registry",
+      "computedHash": "36442c8502d91da49ffe0838391eff59207fe50ca152204b8387e700938eab78"
+    },
+    "android-compose-foundations": {
+      "source": "krutikJain/android-agent-skills",
+      "sourceType": "autoskills-registry",
+      "computedHash": "2fa62193bee29d68015b18b6473c1eb5db5618ed9d0209301259a0bb3f26d7e5"
+    },
+    "android-coroutines-flow": {
+      "source": "krutikJain/android-agent-skills",
+      "sourceType": "autoskills-registry",
+      "computedHash": "373c0ed1eb6fe061d38ac8ceee04bdb9380c4862596d5515984d5768a85d1aaf"
+    },
+    "android-di-hilt": {
+      "source": "krutikJain/android-agent-skills",
+      "sourceType": "autoskills-registry",
+      "computedHash": "702ff3dba5cd0fe3b87b458dcc256c56d05a9242948407a4e8d4f0eca26bf1f2"
+    },
+    "android-gradle-build-logic": {
+      "source": "krutikJain/android-agent-skills",
+      "sourceType": "autoskills-registry",
+      "computedHash": "a06680cd5c497a398b341e1ac00a2998e76b353efaae2218c8ab1762b2fb8f5c"
+    },
+    "android-kotlin-core": {
+      "source": "krutikJain/android-agent-skills",
+      "sourceType": "autoskills-registry",
+      "computedHash": "0a510e8fc8e64eb8ea1d2042a79a07f92eb10bf9b4f8461deea5cff4b745966a"
+    },
+    "android-networking-retrofit-okhttp": {
+      "source": "krutikJain/android-agent-skills",
+      "sourceType": "autoskills-registry",
+      "computedHash": "8cb3647f71f6904752a1681eb575ea1fda35cf7d769834b4034b9f52ac0d146e"
+    },
+    "android-testing-unit": {
+      "source": "krutikJain/android-agent-skills",
+      "sourceType": "autoskills-registry",
+      "computedHash": "7848ad8738bc5a20458ff3b60a520aae13d509c097354dfa07244952c7472bcd"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Replace the random notification channel scheme with two fixed channels (one per severity tier) to ensure consistent FCM delivery
- Gate FCM topic subscription behind `POST_NOTIFICATIONS` runtime permission so the app never subscribes silently on Android 13+
- Re-evaluate the notification permission `CardView` in `onResume` so the UI reflects permission state after returning from system settings
- Decouple FCM subscription state from the preference switch so toggling the switch only controls the preference, not the subscription directly
- Exclude `SharedPreferences` from Android Auto Backup to prevent stale permission state being restored on fresh installs

## Commits

| Commit | Description |
|---|---|
| `75940d9` | fix: replace random channel scheme with two fixed notification channels |
| `c4a66f0` | fix: gate FCM subscription on permission and fix POST_NOTIFICATIONS cardview flow |
| `c6eecfc` | fix: exclude SharedPreferences from Auto Backup to prevent stale permission restore |
| `5e5bf47` | fix: re-evaluate notification permission cardview in onResume |
| `6564d9a` | fix: decouple FCM subscription from user preference switch state |
| `912d48f` | feat: add Android developer agent foundation skills |

## Test plan

- [ ] Fresh install on Android 13+ device — verify notification permission prompt appears and FCM subscription only happens after granting
- [ ] Grant permission → open Settings → revoke permission → return to app — verify the permission `CardView` reappears in `onResume`
- [ ] Toggle notification switch off/on in Settings — verify FCM subscription state matches correctly
- [ ] Uninstall and reinstall — verify stale preference state is not restored from backup
- [ ] Receive FCM push notification — verify it arrives in the correct fixed channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)