### PR TITLE
ci: add workflow_dispatch trigger to release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
@
## What

Adds a `workflow_dispatch` trigger to the `release-please` workflow.

## Why

- The workflow previously only ran on `push` to `main`, so it could not be triggered manually (`gh workflow run` returned HTTP 422).
- The last run failed with `startup_failure` because the repo Actions allow-list pattern was `googleapis/release-please-action` (no `@*` wildcard), which blocked the SHA-pinned action. The allow-list has been corrected to `googleapis/release-please-action@*`.
- Merging this PR re-triggers release-please on `main` with the corrected allow-list, and enables manual dispatch going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@